### PR TITLE
Automate GovCloud Iron Bank Headlamp install fixes

### DIFF
--- a/charts/enbuild/README.md
+++ b/charts/enbuild/README.md
@@ -31,6 +31,12 @@ vivsoft/enbuild	0.0.12        	1.0.10      	A Helm chart for ENBUILD
 ❯ helm upgrade --install  enbuild vivsoft/enbuild --namespace enbuild --create-namespace  --version 0.0.12
 ```
 
+Iron Bank examples:
+
+- Base Iron Bank install: `examples/enbuild/quick_install_ib.yaml`
+- Iron Bank install with Headlamp enabled: `examples/enbuild/quick_install_ib_headlamp.yaml`
+- Headlamp example notes: `examples/enbuild/quick_install_ib_headlamp.md`
+
 # Uninstalling the Chart
 
 To uninstall/delete the `enbuild` deployment:
@@ -57,6 +63,7 @@ To uninstall/delete the `enbuild` deployment:
 | `global.istio.gateway`                       | Istio gateway to use for creating Virtual Service.                                                                                                                                               | `istio-system/main`   |
 | `global.image.registry`                      | Container registry to pull images from                                                                                                                                                           | `registry.gitlab.com` |
 | `global.image.pullPolicy`                    | Container imagePullPolicy                                                                                                                                                                        | `Always`              |
+| `global.storageClass`                        | Explicit StorageClass to use for stateful dependencies when the cluster has no default StorageClass                                                                                              | `""`                  |
 | `global.image.registry_credentials`          | if the image.registry is private container registry, provide the credentials                                                                                                                     | `{}`                  |
 | `global.image.registry_credentials.username` | Container registry Username                                                                                                                                                                      | `""`                  |
 | `global.image.registry_credentials.password` | Container registry password                                                                                                                                                                      | `""`                  |
@@ -99,6 +106,7 @@ To uninstall/delete the `enbuild` deployment:
 | `mongodb.mongo_server`        | If `mongodb.enabled` is false , provide the right cosmosDB/DocumentDB endpoint                                                 | `""`                                          |
 | `mongodb.image.repository`    | Container repository for mongodb Container                                                                                     | `enbuild-staging/vivsoft-platform-ui/mongodb` |
 | `mongodb.image.tag`           | Container tag for mongodb Container                                                                                            | `4.4.5`                                       |
+| `mongodb.storageClassName`    | Explicit StorageClass for MongoDB PVCs. If empty, uses `global.storageClass`                                                   | `""`                                          |
 
 ### ENBUILD UI Services parameters
 
@@ -141,6 +149,8 @@ To uninstall/delete the `enbuild` deployment:
 | `enbuildConsumer.image.repository` | Container repository for enbuildConsumer                               | `enbuild-staging/vivsoft-platform-ui/enbuild-mq-consumer` |
 | `enbuildConsumer.image.tag`        | Container image tag. Skip to use the HelmChart appVersion as Image Tag | `undefined`                                               |
 | `enbuildConsumer.replicas`         | Container enbuildConsumer Replicas                                     | `1`                                                       |
+| `enbuildConsumer.command`          | Command override for the MQ consumer container                         | `["npm"]`                                                 |
+| `enbuildConsumer.args`             | Args override for the MQ consumer container                            | `["run","run:mq:all"]`                                    |
 
 ### ENBUILD AI Services parameters
 

--- a/charts/enbuild/README.md
+++ b/charts/enbuild/README.md
@@ -37,6 +37,8 @@ Iron Bank examples:
 - Iron Bank install with Headlamp enabled: `examples/enbuild/quick_install_ib_headlamp.yaml`
 - Headlamp example notes: `examples/enbuild/quick_install_ib_headlamp.md`
 
+The Iron Bank examples assume the Helm release name is `enbuild-ib`, which means the generated image pull secret is `enbuild-ib-image-pull-secret`. If you install with a different release name, update the RabbitMQ and Headlamp pull secret references in the example values accordingly.
+
 # Uninstalling the Chart
 
 To uninstall/delete the `enbuild` deployment:

--- a/charts/enbuild/templates/enbuild-mq.yaml
+++ b/charts/enbuild/templates/enbuild-mq.yaml
@@ -52,11 +52,14 @@ spec:
         #     - node
         #     - src/queue/testConnection.js
         name: enbuild-mq
+{{- with .Values.enbuildConsumer.args }}
         args:
-          - run
-          - run:mq:all
+{{ toYaml . | indent 10 }}
+{{- end }}
+{{- with .Values.enbuildConsumer.command }}
         command:
-          - npm
+{{ toYaml . | indent 10 }}
+{{- end }}
         # ports:
         # - containerPort: 8080
         resources: {{- toYaml .Values.enbuildConsumer.resources | nindent 10 }}

--- a/charts/enbuild/templates/mongodb.yaml
+++ b/charts/enbuild/templates/mongodb.yaml
@@ -66,6 +66,10 @@ spec:
     spec:
       accessModes:
       - ReadWriteOnce
+{{- $mongoStorageClass := .Values.mongodb.storageClassName | default .Values.global.storageClass }}
+{{- if $mongoStorageClass }}
+      storageClassName: {{ $mongoStorageClass }}
+{{- end }}
       resources:
         requests:
           storage: 10Gi

--- a/charts/enbuild/values.yaml
+++ b/charts/enbuild/values.yaml
@@ -11,6 +11,7 @@
 ## @param global.istio.gateway Istio gateway to use for creating Virtual Service.
 ## @param global.image.registry [default: registry.gitlab.com]  Container registry to pull images from
 ## @param global.image.pullPolicy [default: Always]  Container imagePullPolicy
+## @param global.storageClass [nullable,string] Explicit StorageClass to use for stateful dependencies when the cluster has no default StorageClass
 ## @param global.image.registry_credentials [nullable,object] if the image.registry is private container registry, provide the credentials
 ## @param global.image.registry_credentials.username [nullable,string]  Container registry Username
 ## @param global.image.registry_credentials.password  [nullable,string] Container registry password
@@ -33,6 +34,7 @@ global:
     registry: registry.gitlab.com
     pullPolicy: Always
     registry_credentials: {}
+  storageClass: ""
     # username: registry_user_name
     # password: registry_password
 
@@ -97,11 +99,13 @@ rabbitmq:
 ## @param mongodb.mongo_server [nullable,string] If `mongodb.enabled` is false , provide the right cosmosDB/DocumentDB endpoint
 ## @param mongodb.image.repository Container repository for mongodb Container
 ## @param mongodb.image.tag Container tag for mongodb Container
+## @param mongodb.storageClassName [nullable,string] Explicit StorageClass for MongoDB PVCs. If empty, uses `global.storageClass`
 mongodb:
   enabled: true
   mongo_root_username: "enbuild"
   mongo_root_password: "mongo_root_password"
   mongo_server: "If you are using cosmosDB then set the right cosmosDB endpoint as mongo_server and set the enabled=false"
+  storageClassName: ""
   image:
     repository: enbuild-staging/vivsoft-platform-ui/mongodb
     tag: 4.4.5
@@ -157,10 +161,17 @@ enbuildUser:
 ## @param enbuildConsumer.image.repository  Container repository for enbuildConsumer
 ## @param enbuildConsumer.image.tag [nullable] Container image tag. Skip to use the HelmChart appVersion as Image Tag
 ## @param enbuildConsumer.replicas Container enbuildConsumer Replicas
+## @param enbuildConsumer.command Command override for the MQ consumer container
+## @param enbuildConsumer.args Args override for the MQ consumer container
 enbuildConsumer:
   image:
     repository: enbuild-staging/vivsoft-platform-ui/enbuild-mq-consumer
   replicas: 1
+  command:
+    - npm
+  args:
+    - run
+    - run:mq:all
 
 ## @section ENBUILD AI Services parameters
 ## @param enbuildAI.image.repository  Container repository for enbuildAI

--- a/examples/enbuild/quick_install_ib.yaml
+++ b/examples/enbuild/quick_install_ib.yaml
@@ -24,7 +24,7 @@ rabbitmq:
     repository: ironbank/bitnami/rabbitmq
     tag: 3.12.14
     pullSecrets:
-      - enbuild-image-pull-secret
+      - enbuild-ib-image-pull-secret
 
 enbuildUi:
   image:

--- a/examples/enbuild/quick_install_ib.yaml
+++ b/examples/enbuild/quick_install_ib.yaml
@@ -1,11 +1,15 @@
 global:
   AppVersion: 1.0.30
+  # Set this explicitly when the cluster does not define a default StorageClass.
+  # The GovCloud EKS validation used gp2.
+  storageClass: gp2
   image:
     registry: registry1.dso.mil
     pullPolicy: Always
     registry_credentials:
       username: REGISTRY1_USER_NAME
       password: REGISTRY1_PASSWORD
+
 mongodb:
   enabled: true
   mongo_root_username: "enbuild"
@@ -13,6 +17,7 @@ mongodb:
   image:
     repository: ironbank/opensource/mongodb/mongodb
     tag: 4.4.5
+
 rabbitmq:
   image:
     registry: registry1.dso.mil
@@ -20,15 +25,29 @@ rabbitmq:
     tag: 3.12.14
     pullSecrets:
       - enbuild-image-pull-secret
+
 enbuildUi:
   image:
     repository: ironbank/vivsoft/enbuild/frontend
+    tag: 1.0.30-5101868
+
 enbuildBk:
   image:
     repository: ironbank/vivsoft/enbuild/backend
+    tag: 1.0.30-5101272
+
 enbuildUser:
   image:
     repository: ironbank/vivsoft/enbuild/enbuild-user
+    tag: 1.0.30-5098733
+
 enbuildConsumer:
   image:
     repository: ironbank/vivsoft/enbuild/enbuild-mq
+    tag: 1.0.30-5101532
+  # The Iron Bank MQ image works when npm resolves node from /usr/bin first.
+  command:
+    - /bin/sh
+    - -lc
+  args:
+    - export PATH=/usr/bin:/usr/sbin:/bin:/sbin:/usr/local/bin && exec /usr/bin/npm run run:mq:all

--- a/examples/enbuild/quick_install_ib_headlamp.md
+++ b/examples/enbuild/quick_install_ib_headlamp.md
@@ -1,0 +1,31 @@
+# Iron Bank Headlamp Example
+
+This example extends `quick_install_ib.yaml` for installs that also need Headlamp enabled with Iron Bank images.
+
+It captures the settings that were validated on a disposable GovCloud EKS cluster:
+
+- ENBUILD core services pulled from Iron Bank
+- Headlamp pulled from Iron Bank
+- Headlamp kubeconfig init container pulled from Iron Bank
+- explicit `storageClass` for stateful dependencies when the cluster has no default StorageClass
+- MQ runtime override for the Iron Bank MQ image so `npm` resolves `node` from `/usr/bin`
+
+Use this example when you want:
+
+- Iron Bank-backed ENBUILD images
+- Headlamp enabled through `lightning_features.operations_lightning.headlamp`
+- in-cluster Headlamp access through `/headlamp/`
+
+Important notes:
+
+1. StorageClass
+
+If your target cluster does not define a default StorageClass, set `global.storageClass` to the class you want ENBUILD to use. The validated GovCloud install used `gp2`.
+
+2. MQ runtime
+
+The Iron Bank MQ image required the example's explicit command/args override so `npm` uses the working `/usr/bin/node` path.
+
+3. Headlamp images
+
+The example overrides both the main Headlamp image and the kubeconfig init container image to approved Iron Bank references.

--- a/examples/enbuild/quick_install_ib_headlamp.md
+++ b/examples/enbuild/quick_install_ib_headlamp.md
@@ -29,3 +29,9 @@ The Iron Bank MQ image required the example's explicit command/args override so 
 3. Headlamp images
 
 The example overrides both the main Headlamp image and the kubeconfig init container image to approved Iron Bank references.
+
+4. Image pull secret name
+
+The chart creates the image pull secret as `<release-name>-image-pull-secret`. This example assumes the Helm release name is `enbuild-ib`, so the subchart image pull secret references are set to `enbuild-ib-image-pull-secret`.
+
+If you install with a different release name, update the RabbitMQ and Headlamp pull secret references in the example values accordingly.

--- a/examples/enbuild/quick_install_ib_headlamp.yaml
+++ b/examples/enbuild/quick_install_ib_headlamp.yaml
@@ -28,7 +28,7 @@ rabbitmq:
     repository: ironbank/bitnami/rabbitmq
     tag: 3.12.14
     pullSecrets:
-      - enbuild-image-pull-secret
+      - enbuild-ib-image-pull-secret
 
 enbuildUi:
   image:
@@ -63,7 +63,7 @@ headlamp:
     tag: v0.36.0
     pullPolicy: Always
   imagePullSecrets:
-    - name: enbuild-image-pull-secret
+    - name: enbuild-ib-image-pull-secret
   initContainers:
     - command:
         - /bin/sh

--- a/examples/enbuild/quick_install_ib_headlamp.yaml
+++ b/examples/enbuild/quick_install_ib_headlamp.yaml
@@ -1,0 +1,110 @@
+global:
+  AppVersion: 1.0.30
+  # Set this explicitly when the cluster does not define a default StorageClass.
+  # The GovCloud EKS validation used gp2.
+  storageClass: gp2
+  image:
+    registry: registry1.dso.mil
+    pullPolicy: Always
+    registry_credentials:
+      username: REGISTRY1_USER_NAME
+      password: REGISTRY1_PASSWORD
+
+lightning_features:
+  operations_lightning:
+    headlamp: true
+
+mongodb:
+  enabled: true
+  mongo_root_username: "enbuild"
+  mongo_root_password: "SuperSecret"
+  image:
+    repository: ironbank/opensource/mongodb/mongodb
+    tag: 4.4.5
+
+rabbitmq:
+  image:
+    registry: registry1.dso.mil
+    repository: ironbank/bitnami/rabbitmq
+    tag: 3.12.14
+    pullSecrets:
+      - enbuild-image-pull-secret
+
+enbuildUi:
+  image:
+    repository: ironbank/vivsoft/enbuild/frontend
+    tag: 1.0.30-5101868
+
+enbuildBk:
+  image:
+    repository: ironbank/vivsoft/enbuild/backend
+    tag: 1.0.30-5101272
+
+enbuildUser:
+  image:
+    repository: ironbank/vivsoft/enbuild/enbuild-user
+    tag: 1.0.30-5098733
+
+enbuildConsumer:
+  image:
+    repository: ironbank/vivsoft/enbuild/enbuild-mq
+    tag: 1.0.30-5101532
+  # The Iron Bank MQ image works when npm resolves node from /usr/bin first.
+  command:
+    - /bin/sh
+    - -lc
+  args:
+    - export PATH=/usr/bin:/usr/sbin:/bin:/sbin:/usr/local/bin && exec /usr/bin/npm run run:mq:all
+
+headlamp:
+  image:
+    registry: registry1.dso.mil
+    repository: ironbank/opensource/headlamp-k8s/headlamp
+    tag: v0.36.0
+    pullPolicy: Always
+  imagePullSecrets:
+    - name: enbuild-image-pull-secret
+  initContainers:
+    - command:
+        - /bin/sh
+        - -c
+        - |
+          kubectl config set-cluster main --server=https://kubernetes.default.svc --certificate-authority=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          kubectl config set-credentials main --token=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+          kubectl config set-context main --cluster=main --user=main
+          kubectl config use-context main
+      env:
+        - name: KUBECONFIG
+          value: /home/headlamp/.config/Headlamp/kubeconfigs/config
+      image: registry1.dso.mil/ironbank/opensource/kubernetes/kubectl:v1.34.6
+      imagePullPolicy: Always
+      name: create-kubeconfig
+      securityContext:
+        capabilities:
+          drop:
+            - ALL
+        privileged: false
+        readOnlyRootFilesystem: true
+        runAsGroup: 101
+        runAsNonRoot: true
+        runAsUser: 100
+      volumeMounts:
+        - mountPath: /home/headlamp/.config/Headlamp/kubeconfigs
+          name: kubeconfig
+  config:
+    inCluster: true
+    baseURL: /headlamp
+    pluginsDir: ""
+    watchPlugins: false
+    extraArgs:
+      - -enable-dynamic-clusters
+  volumeMounts:
+    - mountPath: /home/headlamp/.config/Headlamp/kubeconfigs/config
+      name: kubeconfig
+      readOnly: true
+      subPath: config
+  volumes:
+    - name: kubeconfig
+      emptyDir: {}
+  persistentVolumeClaim:
+    enabled: false


### PR DESCRIPTION
## Summary

- add explicit StorageClass support for stateful dependencies when the cluster has no default StorageClass
- add configurable MQ command/args so the Iron Bank MQ image can use the known-good runtime path
- update the Iron Bank install examples to the latest validated ENBUILD image tags
- add a Headlamp-enabled Iron Bank example plus notes from the live GovCloud validation
- fix the Iron Bank example pull secret references so RabbitMQ and Headlamp use the generated release-name-based secret

## Why

A disposable GovCloud validation of ENBUILD + Headlamp succeeded, but it exposed manual interventions that should not be left to operators:

1. The test EKS cluster had `gp2`, but no default StorageClass, so MongoDB/RabbitMQ PVCs stayed pending until `gp2` was marked default.
2. The Iron Bank MQ image pulled successfully, but the chart's default `npm run run:mq:all` path crashed with `libatomic.so.1` missing. The same image worked when forced through `/usr/bin/npm` with `/usr/bin` first in `PATH`.
3. During the post-fix rerun, the chart-generated pull secret existed as `<release-name>-image-pull-secret`, but the Iron Bank examples still pointed RabbitMQ and Headlamp at `enbuild-image-pull-secret`, which broke those pulls.

## What changed

- `charts/enbuild/values.yaml`
  - add `global.storageClass`
  - add `mongodb.storageClassName`
  - add `enbuildConsumer.command`
  - add `enbuildConsumer.args`
- `charts/enbuild/templates/mongodb.yaml`
  - render `storageClassName` from `mongodb.storageClassName` or `global.storageClass`
- `charts/enbuild/templates/enbuild-mq.yaml`
  - render configurable MQ `command` / `args` instead of hardcoding `npm run run:mq:all`
- `examples/enbuild/quick_install_ib.yaml`
  - pin to the latest validated Iron Bank ENBUILD tags
  - set explicit `global.storageClass: gp2`
  - set the known-good MQ runtime override
  - fix RabbitMQ pull secret reference for the documented `enbuild-ib` release
- `examples/enbuild/quick_install_ib_headlamp.yaml`
  - add the validated Headlamp-on-Iron-Bank example
  - use Iron Bank Headlamp + Iron Bank kubectl init container
  - keep the same StorageClass + MQ runtime fixes
  - fix RabbitMQ and Headlamp pull secret references for the documented `enbuild-ib` release
- `examples/enbuild/quick_install_ib_headlamp.md` / `charts/enbuild/README.md`
  - document the validated install path, the release-name-based pull secret assumption, and why the overrides exist

## GovCloud validation evidence

### Baseline validation

- Disposable remote EKS cluster: `enbuild-ibhl-0408` in `us-gov-west-1`
- Namespace / release: `enbuild-ib-test` / `enbuild-ib`
- ENBUILD UI returned `HTTP 200`
- `/headlamp/` returned `HTTP 200`
- backend `/api/health` returned `{"status":"ok"}`
- `/headlamp/config` returned the in-cluster `main` target (`https://kubernetes.default.svc`)
- Helm uninstall succeeded
- Terraform destroy completed with `Destroy complete! Resources: 81 destroyed.`

### Post-fix rerun

- Disposable remote EKS cluster: `enbuild-ibhl-0408b` in `us-gov-west-1`
- Namespace / release: `enbuild-ib-verify2` / `enbuild-ib`
- cluster still had `gp2` but no default StorageClass
- MongoDB PVC bound with `storageClassName: gp2`
- RabbitMQ PVC bound with `storageClassName: gp2`
- Helm reached `STATUS: deployed`
- all ENBUILD, Headlamp, MongoDB, and RabbitMQ workloads became `Running`
- ENBUILD UI returned `HTTP 200`
- `/headlamp/` returned `HTTP 200`
- backend `/api/health` returned `{"status":"ok"}`
- `/headlamp/config` returned the in-cluster `main` target (`https://kubernetes.default.svc`)
- Helm uninstall succeeded
- Terraform destroy completed with `Destroy complete! Resources: 81 destroyed.`
- final AWS/state checks:
  - `aws eks list-clusters` no longer contained `enbuild-ibhl-0408b`
  - VPC `vpc-02c07b2fdc0c9da2a` no longer existed
  - local state file contained `resources 0`

Validated Iron Bank images used in the live test:

- `registry1.dso.mil/ironbank/vivsoft/enbuild/frontend:1.0.30-5101868`
- `registry1.dso.mil/ironbank/vivsoft/enbuild/backend:1.0.30-5101272`
- `registry1.dso.mil/ironbank/vivsoft/enbuild/enbuild-user:1.0.30-5098733`
- `registry1.dso.mil/ironbank/vivsoft/enbuild/enbuild-mq:1.0.30-5101532`
- `registry1.dso.mil/ironbank/opensource/headlamp-k8s/headlamp:v0.36.0`
- `registry1.dso.mil/ironbank/opensource/kubernetes/kubectl:v1.34.6`
- `registry1.dso.mil/ironbank/opensource/mongodb/mongodb:4.4.5`
- `registry1.dso.mil/ironbank/bitnami/rabbitmq:3.12.14`

## Validation on this branch

- `helm lint charts/enbuild`
- `helm template enbuild charts/enbuild -f examples/enbuild/quick_install_ib.yaml`
- `helm template enbuild charts/enbuild -f examples/enbuild/quick_install_ib_headlamp.yaml`
- live GovCloud install, route checks, uninstall, and destroy as summarized above

## Rollback

- isolated chart/example/docs change set on one branch with two commits (`31b045d`, `84d153f`)
- no ENBUILD application source code changes
- revert this PR to return the Helm chart and examples to the prior behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added Iron Bank quick-install examples and Headlamp integration guide with cluster configuration details

* **New Features**
  * Introduced configurable storage class parameters for clusters without default storage classes
  * Added ability to override MQ consumer container startup commands
  * Provided Iron Bank deployment configuration examples (v1.0.30)
  * Added Headlamp cluster dashboard integration example

<!-- end of auto-generated comment: release notes by coderabbit.ai -->