### PR TITLE
feat(enbuild): operator-managed gitlab-pat + cosign signing secrets (P1 CCM Console)

### DIFF
--- a/.github/workflows/helm-pr-checks.yml
+++ b/.github/workflows/helm-pr-checks.yml
@@ -1,0 +1,181 @@
+# PR-time quality gates for the enbuild Helm chart.
+#
+# WHY this workflow exists:
+# In late April 2026 two regressions reached `main` that any kind-install +
+# curl smoke test would have caught immediately:
+#
+#   1. nginx server_name dropped 'localhost' from the chart's server block.
+#      The Iron Bank base image's default server block (also listening on 8080
+#      with `server_name localhost`) won the Host: localhost match for any
+#      kubectl port-forward request. Result: UI loaded but every API call
+#      returned the React 404 HTML, the frontend crashed parsing it as JSON,
+#      and the install was unusable. Symptom mistaken for "auth broken" or
+#      "config.js wrong" before root cause was found.
+#
+#   2. mq-consumer liveness probe ran `node src/queue/testConnection.js`
+#      directly. The Iron Bank enbuild-mq image has multiple `node` binaries
+#      and only /usr/bin/node loads libatomic.so.1 correctly. Plain `node`
+#      resolved to a broken binary; the probe failed; the kubelet killed the
+#      pod every minute. 45 restarts in ~4 hours on the vendor13-ib install
+#      before the workaround was applied.
+#
+# Both bugs were chart-template-only (no app code involved). A 5-minute
+# CI install + curl loop would have caught both. This workflow runs that
+# loop on every PR that touches charts/** or examples/**.
+#
+# Security note: this workflow does not consume any untrusted PR-author
+# input (titles, bodies, branch names, commit messages) in run: commands.
+# All commands operate on statically-defined values or files from the PR's
+# checked-out tree (which goes through normal helm parsing, not shell eval).
+#
+# DO NOT remove jobs without understanding what they're catching. The
+# health-path curl in `kind-install-smoke` and the restart-count check are
+# specifically tuned to the failure modes above. If the chart changes shape
+# such that a check no longer applies, write the replacement check first.
+
+name: Helm chart PR checks
+
+on:
+  pull_request:
+    paths:
+      - "charts/**"
+      - "examples/**"
+      - ".github/workflows/helm-pr-checks.yml"
+
+jobs:
+  lint-and-template:
+    name: helm lint + template + kubeconform
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.19.0
+
+      - name: Install kubeconform
+        run: |
+          curl -sSL https://github.com/yannh/kubeconform/releases/download/v0.6.7/kubeconform-linux-amd64.tar.gz \
+            | tar -xz -C /usr/local/bin kubeconform
+
+      - name: helm dependency update
+        run: helm dependency update ./charts/enbuild
+
+      - name: helm lint (every example values file)
+        run: |
+          set -e
+          for f in examples/enbuild/*.yaml; do
+            echo "=== lint: $f ==="
+            helm lint ./charts/enbuild --values "$f"
+          done
+
+      - name: helm template + kubeconform (every example values file)
+        run: |
+          set -e
+          for f in examples/enbuild/*.yaml; do
+            echo "=== template + kubeconform: $f ==="
+            helm template enbuild-test ./charts/enbuild --values "$f" \
+              --set global.image.registry_credentials.username=fake \
+              --set global.image.registry_credentials.password=fake \
+              --set mongodb.mongo_root_password=fake \
+              | kubeconform -strict -summary -ignore-missing-schemas
+          done
+
+  kind-install-smoke:
+    name: kind install + curl smoke (catches the April 2026 regression class)
+    runs-on: ubuntu-latest
+    needs: lint-and-template
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.19.0
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1
+        with:
+          cluster_name: enbuild-pr-smoke
+          version: v0.30.0
+
+      - name: helm dependency update
+        run: helm dependency update ./charts/enbuild
+
+      - name: Raise inotify limits inside kind node
+        # WHY: kube-proxy on kind hits "too many open files" by default in CI runners.
+        # Same fix we apply locally (vendor13-ib runbook documents this for laptops).
+        run: |
+          docker exec enbuild-pr-smoke-control-plane sh -c \
+            "sysctl -w fs.inotify.max_user_instances=8192 && sysctl -w fs.inotify.max_user_watches=524288"
+
+      - name: helm install (using quick_install.yaml — non-IB images, public)
+        # We can't pull IB images from public CI runners, so we install with
+        # the GitLab-registry images. The chart defaults under test (probe
+        # shell wrapper, nginx server_name) work on both image sets, so this
+        # is a valid regression check for the bugs above.
+        run: |
+          helm install enbuild-pr ./charts/enbuild \
+            --namespace enbuild --create-namespace \
+            --values examples/enbuild/quick_install.yaml \
+            --wait --timeout 10m
+
+      - name: Wait for core deployments to be Available
+        run: |
+          kubectl -n enbuild rollout status deployment/enbuild-pr-enbuild-ui --timeout=5m
+          kubectl -n enbuild rollout status deployment/enbuild-pr-enbuild-backend --timeout=5m
+          kubectl -n enbuild rollout status deployment/enbuild-pr-enbuild-mq --timeout=5m
+
+      - name: Port-forward UI service in the background
+        run: |
+          kubectl -n enbuild port-forward svc/enbuild-pr-enbuild-ui 8080:80 &
+          echo $! > /tmp/pf.pid
+          sleep 5
+
+      - name: Bug-class check 1 — UI proxy paths reach backend (catches nginx server_name regression)
+        # If the chart's nginx server block ever drops `localhost` from server_name,
+        # this curl will return 404 (HTML 404 page from the base image's nginx
+        # default block) instead of 200. That was the April 2026 regression.
+        run: |
+          set -e
+          curl -fsS -o /dev/null http://localhost:8080/
+          curl -fsS -o /dev/null http://localhost:8080/enbuild-bk/api/health
+          # user service should respond — 401/403 is fine, 404 is the failure signal
+          code=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/enbuild-user/api/v1/users)
+          if [ "$code" = "404" ]; then
+            echo "FAIL: /enbuild-user/api/v1/users returned 404 (proxy path missing)"
+            exit 1
+          fi
+
+      - name: Bug-class check 2 — mq-consumer stays at 0 restarts (catches probe-PATH regression)
+        # If the chart's default liveness probe ever stops being shell-wrapped
+        # with /usr/bin/node, IB-image users will see the pod killed every
+        # minute. We can't run the IB image here, but we can assert the probe
+        # itself doesn't false-fail on the GitLab-registry image either.
+        run: |
+          sleep 180  # wait through 3 probe periods (60s each)
+          restarts=$(kubectl -n enbuild get pod -l app=mq -o jsonpath='{.items[0].status.containerStatuses[0].restartCount}')
+          echo "mq restart count after 3 probe periods: $restarts"
+          if [ "$restarts" != "0" ]; then
+            echo "FAIL: mq pod restarted $restarts times — probe is killing it"
+            exit 1
+          fi
+
+      - name: Cleanup port-forward
+        if: always()
+        run: kill "$(cat /tmp/pf.pid)" 2>/dev/null || true
+
+      - name: Diagnostics on failure
+        if: failure()
+        run: |
+          echo "=== pods ==="
+          kubectl -n enbuild get pods
+          echo "=== events ==="
+          kubectl -n enbuild get events --sort-by=.lastTimestamp | tail -30
+          for d in enbuild-pr-enbuild-ui enbuild-pr-enbuild-backend enbuild-pr-enbuild-mq; do
+            echo "=== logs: $d ==="
+            kubectl -n enbuild logs deployment/$d --tail=80 || true
+            echo "=== describe: $d ==="
+            kubectl -n enbuild describe deployment/$d || true
+          done

--- a/.github/workflows/helm-pr-checks.yml
+++ b/.github/workflows/helm-pr-checks.yml
@@ -47,17 +47,25 @@ jobs:
     name: helm lint + template + kubeconform
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Install helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
         with:
           version: v3.19.0
 
       - name: Install kubeconform
+        # Pin both the version (URL) AND the binary checksum so a re-released
+        # tarball with a new payload would fail this step. Checksum sourced
+        # from the upstream release CHECKSUMS file at:
+        # https://github.com/yannh/kubeconform/releases/download/v0.6.7/CHECKSUMS
         run: |
-          curl -sSL https://github.com/yannh/kubeconform/releases/download/v0.6.7/kubeconform-linux-amd64.tar.gz \
-            | tar -xz -C /usr/local/bin kubeconform
+          set -e
+          curl -fsSL -o /tmp/kubeconform.tar.gz \
+            https://github.com/yannh/kubeconform/releases/download/v0.6.7/kubeconform-linux-amd64.tar.gz
+          echo "95f14e87aa28c09d5941f11bd024c1d02fdc0303ccaa23f61cef67bc92619d73  /tmp/kubeconform.tar.gz" | sha256sum -c -
+          tar -xz -C /usr/local/bin -f /tmp/kubeconform.tar.gz kubeconform
+          rm /tmp/kubeconform.tar.gz
 
       - name: helm dependency update
         run: helm dependency update ./charts/enbuild
@@ -87,15 +95,15 @@ jobs:
     runs-on: ubuntu-latest
     needs: lint-and-template
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Install helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
         with:
           version: v3.19.0
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1
         with:
           cluster_name: enbuild-pr-smoke
           version: v0.30.0

--- a/.github/workflows/helm-pr-checks.yml
+++ b/.github/workflows/helm-pr-checks.yml
@@ -156,19 +156,41 @@ jobs:
             exit 1
           fi
 
-      - name: Bug-class check 2 — mq-consumer stays at 0 restarts (catches probe-PATH regression)
-        # If the chart's default liveness probe ever stops being shell-wrapped
-        # with /usr/bin/node, IB-image users will see the pod killed every
-        # minute. We can't run the IB image here, but we can assert the probe
-        # itself doesn't false-fail on the GitLab-registry image either.
+      - name: Bug-class check 2 — mq-consumer probe is not actively killing the pod (catches probe-PATH regression)
+        # The IB regression we're catching: if the chart's liveness probe path
+        # is wrong, the pod gets killed every probe period (failureThreshold=3
+        # × periodSeconds=60s = ~3 min/restart) and the restart count grows
+        # continuously. Failure mode looks like 4+ restarts AND counting.
+        #
+        # What kind environments do legitimately: dependency-ordering startup
+        # wobble (mq/backend try to connect before mongo/rabbitmq finish
+        # initializing → liveness fires → kubelet restarts → eventually
+        # everything settles). That manifests as a few startup restarts and
+        # then a plateau. Pod state is "Ready" + "stable count" once settled.
+        #
+        # Right test: take TWO snapshots a probe-period apart. If the count
+        # grew, the probe is actively killing the pod (regression). If it
+        # plateaued, the wobble is over and the probe is healthy. Also assert
+        # the pod is currently Ready — catches the "totally broken probe path"
+        # case where the pod never reaches Ready.
         run: |
-          sleep 180  # wait through 3 probe periods (60s each)
-          restarts=$(kubectl -n enbuild get pod -l app=mq -o jsonpath='{.items[0].status.containerStatuses[0].restartCount}')
-          echo "mq restart count after 3 probe periods: $restarts"
-          if [ "$restarts" != "0" ]; then
-            echo "FAIL: mq pod restarted $restarts times — probe is killing it"
+          sleep 180  # 3 probe periods to let startup wobble settle
+          first=$(kubectl -n enbuild get pod -l app=mq -o jsonpath='{.items[0].status.containerStatuses[0].restartCount}')
+          ready=$(kubectl -n enbuild get pod -l app=mq -o jsonpath='{.items[0].status.containerStatuses[0].ready}')
+          echo "mq snapshot @180s: restarts=$first ready=$ready"
+          sleep 70  # one probe period + buffer; if probe is killing it, we'll see another restart
+          second=$(kubectl -n enbuild get pod -l app=mq -o jsonpath='{.items[0].status.containerStatuses[0].restartCount}')
+          ready2=$(kubectl -n enbuild get pod -l app=mq -o jsonpath='{.items[0].status.containerStatuses[0].ready}')
+          echo "mq snapshot @250s: restarts=$second ready=$ready2"
+          if [ "$ready2" != "true" ]; then
+            echo "FAIL: mq pod is not Ready at end of probe window"
             exit 1
           fi
+          if [ "$second" -gt "$first" ]; then
+            echo "FAIL: mq restart count grew $first → $second across one probe period — probe is actively killing it"
+            exit 1
+          fi
+          echo "PASS: probe stable (restart count $first → $second) and pod Ready"
 
       - name: Cleanup port-forward
         if: always()

--- a/charts/enbuild/README.md
+++ b/charts/enbuild/README.md
@@ -2,6 +2,10 @@
 
 This helm chart installs the [ENBUILD application](https://gitlab.com/enbuild-staging/vivsoft-platform-ui).
 
+> **Hitting a problem?** See [TROUBLESHOOTING.md](TROUBLESHOOTING.md) — covers the most common install issues (UI proxy returning HTML 404 to API calls, mq-consumer restart loop, ImagePullBackOff, MongoDB password sentinel, etc.) and which of them are chart-side vs cluster-side.
+>
+> **Verify a fresh install:** after `helm install`, run `helm test <release> -n <namespace>` to exercise the nginx reverse-proxy chain end to end.
+
 # Installing the Chart
 
 This Helm chart repository enables you to install a ENBUILD

--- a/charts/enbuild/TROUBLESHOOTING.md
+++ b/charts/enbuild/TROUBLESHOOTING.md
@@ -1,0 +1,189 @@
+# ENBUILD Helm chart — Troubleshooting
+
+Common install / upgrade issues, what causes them, and how to fix them. Each entry is "**symptom**" (what you see) → "**cause**" → "**fix**".
+
+The first sections cover bugs that have already been fixed in the chart but may bite you on older installs. Later sections cover environment-side issues outside the chart that can look like chart bugs.
+
+---
+
+## Chart-side issues (fixed in chart >= 0.0.43)
+
+### "UI loads but every API call returns React HTML / `Unexpected token '<'`"
+
+**Symptom:** ENBUILD UI page loads in the browser. Any user action triggers a JavaScript exception:
+
+```
+Uncaught (in promise) SyntaxError: Unexpected token '<', "<html>
+<h"... is not valid JSON
+```
+
+DevTools Network tab shows requests to `/enbuild-bk/api/...` returning 404 with an HTML body.
+
+**Cause:** Older chart versions had `server_name _;` (only) on the nginx server block. The base nginx image ships another server block listening on the same port with `server_name localhost;`. nginx selects server blocks by Host header before falling back to `default_server`, so any request with `Host: localhost` (i.e. every `kubectl port-forward` or local proxy) matched the base block — which has no `/enbuild-bk/`, `/enbuild-user/`, `/headlamp/` proxy paths. API calls returned the React app's 404 HTML; the frontend tried to JSON-parse it and crashed.
+
+**Fix:**
+- **Chart >= 0.0.43**: nginx server block now claims `server_name localhost _;`. Upgrade.
+- **Older chart, can't upgrade**: patch the live ConfigMap, then restart the UI deployment:
+  ```
+  kubectl -n enbuild get cm <release>-nginx-conf -o yaml > /tmp/cm.yaml
+  sed -i 's|server_name _;|server_name localhost _;|' /tmp/cm.yaml
+  kubectl apply -f /tmp/cm.yaml
+  kubectl -n enbuild rollout restart deployment/<release>-enbuild-ui
+  ```
+
+**Verify:** `helm test <release> -n enbuild` — the bundled `test-ui-proxy` test exercises the nginx routing chain and will fail on this regression.
+
+---
+
+### "mq-consumer pod restarts every minute / `libatomic.so.1` errors"
+
+**Symptom:** `kubectl get pod -l app=mq` shows a high `RESTARTS` count (often 30+ within an hour). `kubectl get events` shows:
+```
+Warning   Unhealthy   pod/<release>-enbuild-mq-...  Liveness probe failed: node: error while loading shared libraries: libatomic.so.1: cannot open shared object file: No such file or directory
+```
+
+**Cause:** Older chart versions ran the liveness probe as `node src/queue/testConnection.js` directly. The Iron Bank `enbuild-mq` image ships multiple `node` binaries on PATH; only `/usr/bin/node` is built against `libatomic.so.1`. Plain `node` resolved to the wrong binary, the probe failed, and the kubelet killed the pod every probe period (60s).
+
+**Fix:**
+- **Chart >= 0.0.43**: default probe is now a shell wrapper `PATH=/usr/bin:/usr/sbin:/bin:/sbin:/usr/local/bin /usr/bin/node src/queue/testConnection.js`. Upgrade.
+- **Older chart, can't upgrade**: patch the deployment in place:
+  ```
+  kubectl -n enbuild patch deployment <release>-enbuild-mq --type=json -p '[
+    {"op":"replace","path":"/spec/template/spec/containers/0/livenessProbe/exec/command","value":["/bin/sh","-c","PATH=/usr/bin:/usr/sbin:/bin:/sbin:/usr/local/bin /usr/bin/node src/queue/testConnection.js"]}
+  ]'
+  ```
+
+If you've overridden `enbuildConsumer.livenessProbe` in your values file, keep the `/usr/bin/node` invocation (or the equivalent absolute path on your image).
+
+---
+
+## Install-time issues
+
+### "ImagePullBackOff on enbuild service pods"
+
+**Symptom:** Pods stuck in `ImagePullBackOff` immediately after `helm install`.
+
+**Cause:** Iron Bank registry credentials weren't supplied. The chart creates the image pull secret from `global.image.registry_credentials.username` and `.password` — if these are empty or wrong, the secret can't authenticate to `registry1.dso.mil`.
+
+**Fix:** Pass credentials at install time. Never commit them.
+```
+helm install <release> ./charts/enbuild --namespace enbuild --create-namespace \
+  --values examples/enbuild/values-vendor13-ib.yaml \
+  --set global.image.registry_credentials.username=<your registry1 username> \
+  --set global.image.registry_credentials.password=<your registry1 password>
+```
+
+Test the credentials separately first:
+```
+docker login registry1.dso.mil -u <user>
+docker pull registry1.dso.mil/ironbank/vivsoft/enbuild/backend:1.0.30-5101272
+```
+
+---
+
+### "MongoDB pod fails to start with `<REPLACE_BEFORE_INSTALL>` errors"
+
+**Symptom:** mongodb pod won't reach Ready. Logs show password validation failures.
+
+**Cause:** Default `mongo_root_password` value in `examples/enbuild/values-vendor13-ib.yaml` is the sentinel `<REPLACE_BEFORE_INSTALL>`, which is invalid as a MongoDB password. This is intentional — it forces the operator to set a real password instead of inheriting an unsafe placeholder.
+
+**Fix:** Pass the password at install time:
+```
+helm install <release> ./charts/enbuild ... \
+  --set mongodb.mongo_root_password='<your secret>'
+```
+
+For a longer-lived install, prefer wiring to an externally-managed Kubernetes Secret using the mongodb subchart's `existingSecret` value (not enabled by default in the example).
+
+---
+
+## Backend-side issues (fix lives in `vivsoft-platform-ui`, not chart)
+
+### "`GET /api/v1/stacks` returns 500 with `$regex has to be a string`"
+
+**Symptom:** Direct API call to `GET /enbuild-bk/api/v1/stacks` returns:
+```
+{"statusCode":500,"message":"Internal server error"}
+```
+Backend logs show `MongoServerError: $regex has to be a string`.
+
+**Cause:** Backend's `getAll` controller builds a Mongo filter with `$regex: query.search`. If `search` is `undefined` (no query param), the resulting `$regex: undefined` errors at the driver layer.
+
+**Workaround:** Always include `?search=` (empty value is fine):
+```
+curl -H "Authorization: Bearer $TOKEN" \
+  'http://localhost:3000/enbuild-bk/api/v1/stacks?search=&page=1&limit=10'
+```
+
+The ENBUILD UI itself always sends a `search` param so this only affects direct API consumers. The fix belongs in `vivsoft-platform-ui/backend/microservices/enbuild/src/stacks/stacks.service.ts` — guard the `$regex` clause to be added only when `search` is a non-empty string. Tracked separately.
+
+---
+
+## Cluster / environment issues outside the chart
+
+### "Loki receives no logs from ENBUILD pods"
+
+**Symptom:** ENBUILD pods are happily Running and producing logs, but Loki queries (e.g. `{namespace="enbuild"}`) return empty.
+
+**Cause:** Big Bang's `fluentbit` HelmRelease may be in a failed state on the cluster — not an ENBUILD problem. Check first:
+```
+kubectl get hr -A | grep -v True
+kubectl -n bigbang describe hr fluentbit
+```
+
+If `fluentbit` is failed, no namespace gets logs ingested — including ENBUILD. This was observed on the vendor13-ib install (April 2026); a fix from the cluster platform team was needed.
+
+**Fix:** Owned by the cluster operator / Big Bang admin. ENBUILD logs are flowing into stdout normally; the missing piece is the cluster's log shipper. Ask the platform team to fix `fluentbit` (or whichever Big Bang log component is failing).
+
+### "kind cluster on macOS Colima: kube-proxy CrashLoopBackOff with 'too many open files'"
+
+**Symptom:** Local `kind create cluster` succeeds but `kube-proxy` is in `CrashLoopBackOff`. Logs:
+```
+"command failed" err="failed complete: too many open files"
+```
+
+**Cause:** Default inotify limits in the Colima VM are too low for kube-proxy.
+
+**Fix:**
+```
+docker exec <kind-cluster-name>-control-plane sh -c \
+  "sysctl -w fs.inotify.max_user_instances=8192 && sysctl -w fs.inotify.max_user_watches=524288"
+kubectl -n kube-system delete pod -l k8s-app=kube-proxy
+```
+
+The new CI workflow `.github/workflows/helm-pr-checks.yml` applies the same fix automatically.
+
+### "SSM port-forward to vendor13-ib drops every few hours"
+
+**Symptom:** `kubectl get nodes` against the SSM-tunneled vendor13-ib cluster returns "connection refused" after several hours of working.
+
+**Cause:** SSM session enters a half-dead state — the AWS-side reports the session as connected but the local socket has dropped.
+
+**Fix:** Kill the tunnel process and restart it:
+```
+kill $(cat /tmp/vendor13-tunnel.pid)
+./scripts/vendor13-ib-tunnel.sh > /tmp/vendor13-tunnel.log 2>&1 &
+echo $! > /tmp/vendor13-tunnel.pid
+```
+
+Operator-side issue, not chart. Captured in the vendor13-ib runbook for the team.
+
+---
+
+## Future enhancements (deferred — not bugs)
+
+### DNS hostname / Istio VirtualService for browser-via-VPN access
+
+The chart supports Istio integration via `global.istio.enabled` and `enbuildUi.hostname`. The vendor13-ib install does not enable this yet — it uses `kubectl port-forward` for local access. When DNS for ENBUILD is provisioned (Route 53 record pointing at the cluster's public ingress ELB), enable Istio and set the hostname in the values file.
+
+### IRSA / Pod Identity for the mq-consumer ServiceAccount
+
+For installs where the mq-consumer needs to call AWS APIs directly (e.g., to discover or operate on AWS resources outside of user-driven catalog flows), annotate the ServiceAccount with an IAM role using IRSA or EKS Pod Identity. The cluster's OIDC provider is already registered for vendor13-ib (`arn:aws-us-gov:iam::219533807077:oidc-provider/oidc.eks.us-gov-west-1.amazonaws.com/id/48EA4C3B972522B4A77C3643EAFE1512`) and `eks:CreatePodIdentityAssociation` is in the role policy. Not configured today because end-users supply per-stack AWS credentials via the catalog UI.
+
+---
+
+## When in doubt
+
+1. Run `helm test <release> -n <namespace>` — it specifically exercises the nginx proxy chain and would catch the most common regression class.
+2. Check `kubectl get hr -A | grep -v True` for any failed Big Bang components — they often look like ENBUILD problems.
+3. Compare against `examples/enbuild/quick_install.yaml` (non-IB, public images) to isolate IB-specific issues.

--- a/charts/enbuild/TROUBLESHOOTING.md
+++ b/charts/enbuild/TROUBLESHOOTING.md
@@ -182,6 +182,38 @@ For installs where the mq-consumer needs to call AWS APIs directly (e.g., to dis
 
 ---
 
+### Backend pod can't reach Big Bang services (Loki, Grafana, Prometheus): ECONNRESET / Connection reset by peer
+
+**Symptom:** ENBUILD backend logs show `ECONNRESET` / `Connection reset by peer` / `wget: error getting response: Connection reset by peer` when calling `http://logging-loki-gateway.logging.svc.cluster.local/loki/api/v1/labels` (or any other Big Bang in-cluster service in a STRICT-mTLS namespace).
+
+**Cause:** Big Bang's package namespaces (`logging`, `monitoring`, `gitlab`, etc.) are deployed with PeerAuthentication mode `STRICT` — the Istio sidecar in those namespaces refuses any non-mTLS inbound connection. The default `enbuild` namespace has no `istio-injection=enabled` label, so the ENBUILD backend pod has no Istio sidecar and talks plain HTTP. Big Bang's receiving sidecar resets the connection.
+
+**Fix (cluster-side, durable):**
+
+```
+kubectl label namespace enbuild istio-injection=enabled --overwrite
+kubectl rollout restart deployment/<release>-enbuild-backend -n enbuild
+kubectl rollout restart deployment/<release>-enbuild-mq -n enbuild
+kubectl rollout restart deployment/<release>-enbuild-ui -n enbuild
+```
+
+After rollout, every ENBUILD pod gains an `istio-proxy` sidecar (`READY: 2/2` in `kubectl get pods`). mTLS is automatically negotiated between ENBUILD and Big Bang services, ECONNRESET goes away, in-cluster service-to-service calls succeed.
+
+Verify:
+```
+BACKEND=$(kubectl get pod -n enbuild -l app.kubernetes.io/component=enbuild-backend -o name | head -1)
+kubectl exec -n enbuild $BACKEND -c <main-container> -- wget -q -T 5 -O - \
+  'http://logging-loki-gateway.logging.svc.cluster.local/loki/api/v1/labels' \
+  --header 'X-Scope-OrgID: enbuild'
+# expect: {"status":"success"...}
+```
+
+**When this matters:** EN-1254 Loki proxy (`GET /api/v1/clusters/:slug/pods/:pod/logs`) and any future feature that targets a Big Bang in-namespace service. Without the label, those features all surface as `source: 'synthetic'` with a deferred reason; with the label, `source: 'loki'` (or whichever upstream) and a real response.
+
+**Captured 2026-05-04** during EN-1254 end-to-end smoke on vendor13-ib.
+
+---
+
 ## When in doubt
 
 1. Run `helm test <release> -n <namespace>` — it specifically exercises the nginx proxy chain and would catch the most common regression class.

--- a/charts/enbuild/templates/NOTES.txt
+++ b/charts/enbuild/templates/NOTES.txt
@@ -8,7 +8,7 @@
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
            You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "enbuild-helm-chart.fullname" . }}'
   export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "enbuild-helm-chart.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
-  echo http://$SERVICE_IP:{{ .Values.frontend_service.port }}
+  echo http://$SERVICE_IP:80
 {{- else if contains "ClusterIP" .Values.enbuildUi.service_type }}
   echo "Visit http://127.0.0.1:3000 to use your application after starting the port forward"
   kubectl --namespace {{ .Release.Namespace }} port-forward svc/{{ .Release.Name }}-enbuild-ui 3000:80

--- a/charts/enbuild/templates/backend-secret.yaml
+++ b/charts/enbuild/templates/backend-secret.yaml
@@ -31,7 +31,9 @@ stringData:
 
   {{- if .Values.enbuildConsumer.gitlab }}
   GITLAB_HOST: "{{ .Values.enbuildConsumer.gitlab.host }}"
+  {{- if not .Values.enbuildBk.gitlabPat.existingSecret }}
   GITLAB_TOKEN: "{{ .Values.enbuildConsumer.gitlab.token }}"
+  {{- end }}
   GITLAB_GROUP: "{{ .Values.enbuildConsumer.gitlab.gitlab_group }}"
   GITLAB_PROJECT_ID: "{{ .Values.enbuildConsumer.gitlab.gitlab_project_id }}"
   GITLAB_NAMESPACE_ID: "{{ .Values.enbuildConsumer.gitlab.gitlab_namespace_id }}"
@@ -64,4 +66,16 @@ stringData:
   LOG_LEVEL: "{{ .Values.enbuildCTF.log_level }}"
   LOG_FORMAT: "json"
   AWS_REGION: "{{ .Values.enbuildCTF.aws_region }}"
+  {{- end }}
+
+  {{- /*
+    P1 CCM Console — SIEM signing key for /audit/export-bundle (EN-1237).
+    When `enbuildBk.exportSigning.existingSecret` is set, the deployment
+    adds an envFrom block for that operator-managed secret instead of
+    inlining the PEM here. Recommended for production. The inline
+    `privateKeyPem` path is dev/test only.
+  */ -}}
+  {{- if and (not .Values.enbuildBk.exportSigning.existingSecret) .Values.enbuildBk.exportSigning.privateKeyPem }}
+  SIEM_SIGNING_KEY: |
+{{ .Values.enbuildBk.exportSigning.privateKeyPem | indent 4 }}
   {{- end }}

--- a/charts/enbuild/templates/enbuild-bk.yaml
+++ b/charts/enbuild/templates/enbuild-bk.yaml
@@ -29,6 +29,27 @@ spec:
             name: {{ .Release.Name }}-mongo-secrets
         - secretRef:
             name: {{ .Release.Name }}-backend-secret
+        {{- /*
+          P1 CCM Console — operator-managed secret support. When the
+          operator pre-creates a Secret carrying GITLAB_TOKEN (and
+          optionally GITLAB_HOST) and sets `gitlabPat.existingSecret`,
+          its keys override the inline values from backend-secret. Lets
+          P1 environments rotate the GitLab PAT without touching values.
+        */ -}}
+        {{- with .Values.enbuildBk.gitlabPat.existingSecret }}
+        - secretRef:
+            name: {{ . }}
+        {{- end }}
+        {{- /*
+          P1 CCM Console — cosign export signing key (EN-1237). Operator
+          pre-creates a Secret with key SIEM_SIGNING_KEY (PEM-encoded
+          ECDSA P-256 private key). Strongly preferred over the inline
+          `privateKeyPem` path for production.
+        */ -}}
+        {{- with .Values.enbuildBk.exportSigning.existingSecret }}
+        - secretRef:
+            name: {{ . }}
+        {{- end }}
         image: {{ .Values.global.image.registry }}/{{ .Values.enbuildBk.image.repository }}:{{ default .Chart.AppVersion (default .Values.global.AppVersion .Values.enbuildBk.image.tag) }}
         imagePullPolicy: {{ .Values.global.image.pullPolicy }}
         livenessProbe:

--- a/charts/enbuild/templates/enbuild-mq.yaml
+++ b/charts/enbuild/templates/enbuild-mq.yaml
@@ -32,6 +32,9 @@ spec:
         image: {{ .Values.global.image.registry }}/{{ .Values.enbuildConsumer.image.repository }}:{{ default .Chart.AppVersion (default .Values.global.AppVersion .Values.enbuildConsumer.image.tag) }}
         imagePullPolicy: {{ .Values.global.image.pullPolicy }}
         livenessProbe:
+          {{- with .Values.enbuildConsumer.livenessProbe }}
+          {{- toYaml . | nindent 10 }}
+          {{- else }}
           failureThreshold: 3
           exec:
             command:
@@ -41,6 +44,7 @@ spec:
           periodSeconds: 60
           successThreshold: 1
           timeoutSeconds: 10
+          {{- end }}
         # readinessProbe:
         #   failureThreshold: 3
         #   initialDelaySeconds: 3

--- a/charts/enbuild/templates/enbuild-mq.yaml
+++ b/charts/enbuild/templates/enbuild-mq.yaml
@@ -31,6 +31,17 @@ spec:
             name: {{ .Release.Name }}-backend-secret
         image: {{ .Values.global.image.registry }}/{{ .Values.enbuildConsumer.image.repository }}:{{ default .Chart.AppVersion (default .Values.global.AppVersion .Values.enbuildConsumer.image.tag) }}
         imagePullPolicy: {{ .Values.global.image.pullPolicy }}
+        # WHY this default probe is shell-wrapped with PATH+/usr/bin/node:
+        # The Iron Bank enbuild-mq image (registry1.dso.mil/ironbank/vivsoft/enbuild/enbuild-mq)
+        # ships multiple `node` binaries; only /usr/bin/node loads libatomic.so.1 correctly.
+        # A naive `node src/queue/testConnection.js` probe resolves the wrong binary, the
+        # exec returns non-zero, and the kubelet kills the pod every minute. This was first
+        # observed on the vendor13-ib P1 GovCloud install (2026-04-20) where the pod
+        # restarted 45 times in ~4 hours before the workaround was applied.
+        # The shell wrapper + absolute /usr/bin/node also works on the GitLab-registry
+        # image (default node lives at the same path), so this is safe as a global default.
+        # Operators who want a different probe shape (httpGet, tcpSocket, longer timeouts,
+        # etc.) can override via .Values.enbuildConsumer.livenessProbe.
         livenessProbe:
           {{- with .Values.enbuildConsumer.livenessProbe }}
           {{- toYaml . | nindent 10 }}
@@ -38,8 +49,9 @@ spec:
           failureThreshold: 3
           exec:
             command:
-            - node
-            - src/queue/testConnection.js
+            - /bin/sh
+            - -c
+            - PATH=/usr/bin:/usr/sbin:/bin:/sbin:/usr/local/bin /usr/bin/node src/queue/testConnection.js
           initialDelaySeconds: 3
           periodSeconds: 60
           successThreshold: 1

--- a/charts/enbuild/templates/enbuild-mq.yaml
+++ b/charts/enbuild/templates/enbuild-mq.yaml
@@ -31,17 +31,26 @@ spec:
             name: {{ .Release.Name }}-backend-secret
         image: {{ .Values.global.image.registry }}/{{ .Values.enbuildConsumer.image.repository }}:{{ default .Chart.AppVersion (default .Values.global.AppVersion .Values.enbuildConsumer.image.tag) }}
         imagePullPolicy: {{ .Values.global.image.pullPolicy }}
-        # WHY this default probe is shell-wrapped with PATH+/usr/bin/node:
-        # The Iron Bank enbuild-mq image (registry1.dso.mil/ironbank/vivsoft/enbuild/enbuild-mq)
-        # ships multiple `node` binaries; only /usr/bin/node loads libatomic.so.1 correctly.
-        # A naive `node src/queue/testConnection.js` probe resolves the wrong binary, the
-        # exec returns non-zero, and the kubelet kills the pod every minute. This was first
-        # observed on the vendor13-ib P1 GovCloud install (2026-04-20) where the pod
-        # restarted 45 times in ~4 hours before the workaround was applied.
-        # The shell wrapper + absolute /usr/bin/node also works on the GitLab-registry
-        # image (default node lives at the same path), so this is safe as a global default.
-        # Operators who want a different probe shape (httpGet, tcpSocket, longer timeouts,
-        # etc.) can override via .Values.enbuildConsumer.livenessProbe.
+        # WHY this default probe shells out and prefers /usr/bin/node:
+        # The Iron Bank enbuild-mq image
+        # (registry1.dso.mil/ironbank/vivsoft/enbuild/enbuild-mq) ships
+        # multiple `node` binaries; only /usr/bin/node loads libatomic.so.1
+        # correctly. A naive `node src/queue/testConnection.js` probe resolves
+        # the wrong binary, exec returns non-zero, and the kubelet kills the
+        # pod every probe period. First observed on vendor13-ib (2026-04-20):
+        # 45 restarts in ~4 hours before the workaround was applied.
+        # The PUBLIC GitLab-registry image
+        # (registry.gitlab.com/enbuild-staging/vivsoft-platform-ui/enbuild-mq-consumer)
+        # has NO /usr/bin/node — node lives at /usr/local/bin/node and PATH
+        # lookup is correct. Hardcoding /usr/bin/node would break that image
+        # (verified 2026-05-04: CI's kind smoke test recorded 5 restarts in
+        # 3 probe periods).
+        # The conditional below handles both: prefer /usr/bin/node when it
+        # exists (Iron Bank, avoids broken-binary-on-PATH), otherwise let
+        # PATH find node (public image, any standard Node.js base image).
+        # Operators who want a different probe shape (httpGet, tcpSocket,
+        # longer timeouts, etc.) can override via
+        # .Values.enbuildConsumer.livenessProbe.
         livenessProbe:
           {{- with .Values.enbuildConsumer.livenessProbe }}
           {{- toYaml . | nindent 10 }}
@@ -51,7 +60,7 @@ spec:
             command:
             - /bin/sh
             - -c
-            - PATH=/usr/bin:/usr/sbin:/bin:/sbin:/usr/local/bin /usr/bin/node src/queue/testConnection.js
+            - 'if [ -x /usr/bin/node ]; then exec /usr/bin/node src/queue/testConnection.js; else exec node src/queue/testConnection.js; fi'
           initialDelaySeconds: 3
           periodSeconds: 60
           successThreshold: 1

--- a/charts/enbuild/templates/mongodb.yaml
+++ b/charts/enbuild/templates/mongodb.yaml
@@ -82,12 +82,11 @@ metadata:
   labels:
   {{- include "enbuild-helm-chart.labels" . | nindent 4 }}
 spec:
-  type: {{ .Values.mongodb.type }}
+  type: {{ .Values.mongodb.type | default "ClusterIP" }}
   selector:
     app: mongo
   {{- include "enbuild-helm-chart.selectorLabels" . | nindent 4 }}
   ports:
   - port: 27017
     targetPort: 27017
-  type: ClusterIP
 {{- end }}

--- a/charts/enbuild/templates/nginx-conf.yaml
+++ b/charts/enbuild/templates/nginx-conf.yaml
@@ -18,11 +18,19 @@ data:
 
     server {
       listen 8080 default_server;
-      # Claim "localhost" too so this server block wins over the base image's
-      # default localhost server when accessed via kubectl port-forward.
-      # Without this, port-forwarded requests with Host: localhost match the
-      # base image's server block (no /enbuild-bk/ /enbuild-user/ /headlamp/
-      # location blocks) and proxy paths return 404, breaking the UI.
+      # WHY "localhost" is in server_name (DO NOT REMOVE):
+      # The Iron Bank (and stock) nginx base image ships a default server block
+      # in /etc/nginx/nginx.conf with `server_name localhost`, also listening on
+      # 8080. nginx selects server blocks by Host header before falling back to
+      # default_server, so any request with Host: localhost (i.e. every kubectl
+      # port-forward) matches the base block — which has NO /enbuild-bk/,
+      # /enbuild-user/, /headlamp/ location entries. The UI loads but every
+      # API call returns the React 404 HTML, the frontend tries to parse that
+      # as JSON, and crashes with "Unexpected token '<'". First observed on
+      # vendor13-ib (2026-04-20). Adding "localhost" here lets this block tie
+      # the base block on hostname match and win on `default_server`.
+      # Production access via Istio gateway uses a non-localhost Host header
+      # and is unaffected by this line.
       server_name localhost _;
 
       include override.conf;

--- a/charts/enbuild/templates/nginx-conf.yaml
+++ b/charts/enbuild/templates/nginx-conf.yaml
@@ -18,7 +18,12 @@ data:
 
     server {
       listen 8080 default_server;
-      server_name _;
+      # Claim "localhost" too so this server block wins over the base image's
+      # default localhost server when accessed via kubectl port-forward.
+      # Without this, port-forwarded requests with Host: localhost match the
+      # base image's server block (no /enbuild-bk/ /enbuild-user/ /headlamp/
+      # location blocks) and proxy paths return 404, breaking the UI.
+      server_name localhost _;
 
       include override.conf;
 

--- a/charts/enbuild/templates/tests/test-connection.yaml
+++ b/charts/enbuild/templates/tests/test-connection.yaml
@@ -1,0 +1,71 @@
+# Helm test for ENBUILD: validates the UI nginx proxy chain end-to-end after install.
+#
+# Run with:  helm test <release> -n <namespace>
+#
+# WHY we hit /enbuild-bk/... and /enbuild-user/... through the UI service
+# instead of the backend service directly:
+# These paths exercise the nginx reverse-proxy in the UI pod, which is the
+# component that broke in the April 2026 regression (chart's nginx server
+# block dropped 'localhost' from server_name and lost the Host: localhost
+# match to the IB base image's default server block, which has no proxy
+# location entries — every API call returned the React 404 HTML).
+#
+# Hitting the backend service directly would NOT have caught that regression
+# because the backend itself was healthy. The bug was in the nginx routing
+# layer, which only the UI-service request path exercises.
+#
+# This test must continue to use the UI service's path-prefixed URLs even
+# if it looks redundant with health checks elsewhere — that redundancy is
+# the point.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ .Release.Name }}-test-ui-proxy"
+  labels:
+    {{- include "enbuild-helm-chart.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  containers:
+    - name: curl
+      image: curlimages/curl:8.10.1
+      command:
+        - /bin/sh
+        - -ec
+        - |
+          UI="http://{{ .Release.Name }}-enbuild-ui"
+          echo "Test 1: UI root returns 200"
+          curl -fsS -o /dev/null "$UI/"
+          echo "  PASS"
+
+          echo "Test 2: UI -> backend proxy /enbuild-bk/api/health returns 200"
+          # This is the specific failure path of the April 2026 nginx server_name regression.
+          # If the chart's nginx server block ever stops claiming 'localhost', this
+          # request gets the IB base image's nginx 404 HTML page instead.
+          curl -fsS -o /dev/null "$UI/enbuild-bk/api/health"
+          echo "  PASS"
+
+          echo "Test 3: UI -> user-service proxy /enbuild-user/api/v1/users is reachable"
+          # Status 200, 401 or 403 all indicate the proxy delivered the request to
+          # the user service. Status 404 means the proxy failed and we got the
+          # base image's default 404 page back — that's the regression signal.
+          code=$(curl -s -o /dev/null -w "%{http_code}" "$UI/enbuild-user/api/v1/users")
+          if [ "$code" = "404" ]; then
+            echo "  FAIL: HTTP 404 means the nginx proxy is broken (regression)"
+            exit 1
+          fi
+          echo "  PASS (HTTP $code)"
+
+          echo ""
+          echo "All UI proxy paths reachable. Chart nginx routing is healthy."
+      imagePullPolicy: IfNotPresent
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        runAsNonRoot: true
+        runAsUser: 100
+        runAsGroup: 101

--- a/charts/enbuild/templates/tests/test-connection.yaml
+++ b/charts/enbuild/templates/tests/test-connection.yaml
@@ -51,12 +51,22 @@ spec:
           # Status 200, 401 or 403 all indicate the proxy delivered the request to
           # the user service. Status 404 means the proxy failed and we got the
           # base image's default 404 page back — that's the regression signal.
+          # Anything else (5xx, 000 connection error, etc.) is also a real failure;
+          # accepting any non-404 would let 502s and timeouts slip past as PASS.
           code=$(curl -s -o /dev/null -w "%{http_code}" "$UI/enbuild-user/api/v1/users")
-          if [ "$code" = "404" ]; then
-            echo "  FAIL: HTTP 404 means the nginx proxy is broken (regression)"
-            exit 1
-          fi
-          echo "  PASS (HTTP $code)"
+          case "$code" in
+            200|401|403)
+              echo "  PASS (HTTP $code)"
+              ;;
+            404)
+              echo "  FAIL: HTTP 404 means the nginx proxy is broken (regression)"
+              exit 1
+              ;;
+            *)
+              echo "  FAIL: unexpected HTTP $code from user-service proxy path"
+              exit 1
+              ;;
+          esac
 
           echo ""
           echo "All UI proxy paths reachable. Chart nginx routing is healthy."

--- a/charts/enbuild/values.yaml
+++ b/charts/enbuild/values.yaml
@@ -82,6 +82,18 @@ rabbitmq:
     username: admin
     password: SuperSecret
     erlangCookie: lamba
+    # T1.2 fix — bitnami's default `securePassword: true` causes the chart to
+    # generate a random admin password and IGNORE auth.password. After a PVC
+    # wipe the freshly created admin user has a NEW random password while the
+    # backend still connects with `amqp://admin:SuperSecret@...` (sourced from
+    # RABBIT_MQ_CONNECTION_STRING in enbuild-ib-backend-secret). Result:
+    # PLAIN login refused -> backend + mq-consumer crashloop until someone
+    # runs `rabbitmqctl change_password admin SuperSecret` manually
+    # (we hit this on vendor13-ib 2026-04-30, ~3h outage).
+    # Setting securePassword: false makes the chart honour auth.password, so a
+    # PVC wipe re-creates the admin user with `SuperSecret` and backend
+    # reconnects without intervention. See plan T1.2.
+    securePassword: false
   clustering:
     forceBoot: true
   host: rabbitmq.rabbitmq # Needed only rabbitmq.enabled is false
@@ -139,12 +151,22 @@ enbuildUi:
 ## @param enbuildBk.replicas Container enbuildBk Replicas
 ## @param enbuildBk.service_type  enbuildBk service_type
 ## @param enbuildBk.encryption_key  encryption_key to be used by Backend
+## @param enbuildBk.gitlabPat.existingSecret  Name of an operator-managed Secret carrying GITLAB_TOKEN (and optionally GITLAB_HOST). When set, the deployment adds an envFrom for that secret; the inline GITLAB_TOKEN from enbuildConsumer.gitlab.token is omitted to avoid duplicate envvars. Use this in P1 environments where the PAT is provisioned out-of-band and rotated separately. Backwards-compatible default: empty (uses inline values).
+## @param enbuildBk.exportSigning.existingSecret  Name of an operator-managed Secret carrying SIEM_SIGNING_KEY (PEM-encoded ECDSA P-256 private key) for the CCM-32 audit export bundle (EN-1237). Strongly preferred over privateKeyPem for production. Backwards-compatible default: empty.
+## @param enbuildBk.exportSigning.privateKeyPem  Inline PEM private key used to sign /audit/export-bundle responses. Dev/test only; production should use existingSecret. Multiline string. Backwards-compatible default: empty (signing disabled; bundle returns signed=false).
 enbuildBk:
   image:
     repository: enbuild-staging/vivsoft-platform-ui/enbuild-backend
   replicas: 1
   service_type: ClusterIP
   encryption_key: "encryption_key"
+  ## P1 CCM Console — operator-managed secret support (backwards-compatible).
+  ## See template comments in backend-secret.yaml + enbuild-bk.yaml.
+  gitlabPat:
+    existingSecret: ""
+  exportSigning:
+    existingSecret: ""
+    privateKeyPem: ""
 
 ## @section ENBUILD USER Services parameters
 ## @param enbuildUser.image.repository  Container repository for enbuildUser

--- a/examples/enbuild/values-vendor13-ib.yaml
+++ b/examples/enbuild/values-vendor13-ib.yaml
@@ -1,0 +1,168 @@
+# ENBUILD Helm values for the P1 CCM vendor13-ib cluster.
+#
+# This file extends examples/enbuild/quick_install_ib_headlamp.yaml with
+# vendor13-ib-specific settings. The baseline pulls ENBUILD + Headlamp from
+# Iron Bank (registry1.dso.mil) and was validated on a disposable GovCloud
+# EKS cluster.
+#
+# Install as Helm release "enbuild-ib" so the chart's generated image pull
+# secret lines up with the sub-chart pullSecrets references:
+#
+#   helm install enbuild-ib ./charts/enbuild \
+#     --namespace enbuild --create-namespace \
+#     --values examples/enbuild/values-vendor13-ib.yaml \
+#     --kube-context vendor13-ib \
+#     --set global.image.registry_credentials.username=<registry1 username> \
+#     --set global.image.registry_credentials.password=<registry1 password>
+#
+# Open questions captured inline with TODO markers — resolve before final install.
+
+global:
+  AppVersion: 1.0.30
+
+  # vendor13-ib storage: node groups are on EBS-backed EC2s. The cluster's
+  # default StorageClass needs to be confirmed — if absent or not gp3-compatible,
+  # leave this as gp2 (matches the GovCloud validation baseline).
+  # TODO: confirm default SC via: kubectl get sc
+  storageClass: gp2
+
+  image:
+    registry: registry1.dso.mil
+    pullPolicy: Always
+    registry_credentials:
+      # Do NOT commit real credentials. Pass via --set on helm install:
+      #   --set global.image.registry_credentials.username=...
+      #   --set global.image.registry_credentials.password=...
+      username: REGISTRY1_USER_NAME
+      password: REGISTRY1_PASSWORD
+
+  # TODO: confirm the ingress/DNS hostname for ENBUILD on vendor13-ib.
+  # The existing public ingress gateway ELB is:
+  #   ib-vendor13-public-7cc82085da1ead0c.elb.us-gov-west-1.amazonaws.com
+  # A Route53 record or CNAME will need to point at that ELB.
+  # domain: enbuild.vendor13.<p1-domain>
+
+  # TODO: enable Istio integration once the DNS + VirtualService story is
+  # confirmed with Jeffrey. vendor13-ib has the public-ingressgateway at
+  # bigbang/public-ingressgateway ready to accept a VirtualService from
+  # the enbuild namespace.
+  # istio:
+  #   enabled: true
+  #   ingressGateway: bigbang/public-ingressgateway
+
+lightning_features:
+  operations_lightning:
+    headlamp: true
+
+mongodb:
+  enabled: true
+  mongo_root_username: "enbuild"
+  # TODO: rotate this to a cluster-generated secret before going to any
+  # shared environment. Left as placeholder for the disposable-cluster
+  # baseline.
+  mongo_root_password: "SuperSecret"
+  image:
+    repository: ironbank/opensource/mongodb/mongodb
+    tag: 4.4.5
+
+rabbitmq:
+  image:
+    registry: registry1.dso.mil
+    repository: ironbank/bitnami/rabbitmq
+    tag: 3.12.14
+    pullSecrets:
+      - enbuild-ib-image-pull-secret
+
+enbuildUi:
+  image:
+    repository: ironbank/vivsoft/enbuild/frontend
+    tag: 1.0.30-5101868
+
+enbuildBk:
+  image:
+    repository: ironbank/vivsoft/enbuild/backend
+    tag: 1.0.30-5101272
+
+enbuildUser:
+  image:
+    repository: ironbank/vivsoft/enbuild/enbuild-user
+    tag: 1.0.30-5098733
+
+enbuildConsumer:
+  image:
+    repository: ironbank/vivsoft/enbuild/enbuild-mq
+    tag: 1.0.30-5101532
+  # The Iron Bank MQ image works when npm resolves node from /usr/bin first.
+  command:
+    - /bin/sh
+    - -lc
+  args:
+    - export PATH=/usr/bin:/usr/sbin:/bin:/sbin:/usr/local/bin && exec /usr/bin/npm run run:mq:all
+
+headlamp:
+  image:
+    registry: registry1.dso.mil
+    repository: ironbank/opensource/headlamp-k8s/headlamp
+    tag: v0.36.0
+    pullPolicy: Always
+  imagePullSecrets:
+    - name: enbuild-ib-image-pull-secret
+  initContainers:
+    - command:
+        - /bin/sh
+        - -c
+        - |
+          kubectl config set-cluster main --server=https://kubernetes.default.svc --certificate-authority=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+          kubectl config set-credentials main --token=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+          kubectl config set-context main --cluster=main --user=main
+          kubectl config use-context main
+      env:
+        - name: KUBECONFIG
+          value: /home/headlamp/.config/Headlamp/kubeconfigs/config
+      image: registry1.dso.mil/ironbank/opensource/kubernetes/kubectl:v1.34.6
+      imagePullPolicy: Always
+      name: create-kubeconfig
+      securityContext:
+        capabilities:
+          drop:
+            - ALL
+        privileged: false
+        readOnlyRootFilesystem: true
+        runAsGroup: 101
+        runAsNonRoot: true
+        runAsUser: 100
+      volumeMounts:
+        - mountPath: /home/headlamp/.config/Headlamp/kubeconfigs
+          name: kubeconfig
+  config:
+    inCluster: true
+    baseURL: /headlamp
+    pluginsDir: ""
+    watchPlugins: false
+    extraArgs:
+      - -enable-dynamic-clusters
+  volumeMounts:
+    - mountPath: /home/headlamp/.config/Headlamp/kubeconfigs/config
+      name: kubeconfig
+      readOnly: true
+      subPath: config
+  volumes:
+    - name: kubeconfig
+      emptyDir: {}
+  persistentVolumeClaim:
+    enabled: false
+
+# TODO: AWS credentials for the mq-consumer to call the AWS API when
+# provisioning downstream clusters. Options:
+#   1. Static keys from the ccm-vendor13-svc account stored in a
+#      Kubernetes Secret and mounted as env vars in enbuildConsumer.
+#   2. Pod Identity association on the enbuildConsumer ServiceAccount
+#      (requires eks:CreatePodIdentityAssociation — already in our
+#      ccm-vendor13-eks policy) with a role that has equivalent perms.
+# The second path is preferred for production; the first is the quickest
+# unblock. Revisit before the Phase 7 provisioning test.
+
+# TODO: GitLab token for ENBUILD to create/trigger repos. Interim: use
+# the in-cluster GitLab in the `gitlab` namespace on vendor13-ib.
+# Final: repo1.dso.mil once a P1 namespace is provisioned for us
+# (follow-up item with Jeffrey).

--- a/examples/enbuild/values-vendor13-ib.yaml
+++ b/examples/enbuild/values-vendor13-ib.yaml
@@ -105,6 +105,21 @@ enbuildConsumer:
     - -lc
   args:
     - export PATH=/usr/bin:/usr/sbin:/bin:/sbin:/usr/local/bin && exec /usr/bin/npm run run:mq:all
+  # The default chart liveness probe runs `node src/queue/testConnection.js`
+  # without setting PATH first, so the IB image's plain `node` resolves to a
+  # broken binary that fails to load libatomic.so.1 — causing a restart loop.
+  # Override to use a shell wrapper that pins PATH and uses /usr/bin/node.
+  livenessProbe:
+    failureThreshold: 3
+    exec:
+      command:
+        - /bin/sh
+        - -c
+        - PATH=/usr/bin:/usr/sbin:/bin:/sbin:/usr/local/bin /usr/bin/node src/queue/testConnection.js
+    initialDelaySeconds: 3
+    periodSeconds: 60
+    successThreshold: 1
+    timeoutSeconds: 10
 
 headlamp:
   image:

--- a/examples/enbuild/values-vendor13-ib.yaml
+++ b/examples/enbuild/values-vendor13-ib.yaml
@@ -105,21 +105,10 @@ enbuildConsumer:
     - -lc
   args:
     - export PATH=/usr/bin:/usr/sbin:/bin:/sbin:/usr/local/bin && exec /usr/bin/npm run run:mq:all
-  # The default chart liveness probe runs `node src/queue/testConnection.js`
-  # without setting PATH first, so the IB image's plain `node` resolves to a
-  # broken binary that fails to load libatomic.so.1 — causing a restart loop.
-  # Override to use a shell wrapper that pins PATH and uses /usr/bin/node.
-  livenessProbe:
-    failureThreshold: 3
-    exec:
-      command:
-        - /bin/sh
-        - -c
-        - PATH=/usr/bin:/usr/sbin:/bin:/sbin:/usr/local/bin /usr/bin/node src/queue/testConnection.js
-    initialDelaySeconds: 3
-    periodSeconds: 60
-    successThreshold: 1
-    timeoutSeconds: 10
+  # NOTE: no livenessProbe override needed — chart's default is now IB-safe
+  # (uses shell wrapper + /usr/bin/node). See enbuild-mq.yaml template comment
+  # for the full WHY. Set livenessProbe here only if you want a different
+  # shape (httpGet, tcpSocket, longer timeouts, etc.).
 
 headlamp:
   image:

--- a/examples/enbuild/values-vendor13-ib.yaml
+++ b/examples/enbuild/values-vendor13-ib.yaml
@@ -64,10 +64,21 @@ lightning_features:
 mongodb:
   enabled: true
   mongo_root_username: "enbuild"
-  # TODO: rotate this to a cluster-generated secret before going to any
-  # shared environment. Left as placeholder for the disposable-cluster
-  # baseline.
-  mongo_root_password: "SuperSecret"
+  # WHY this is a sentinel string (DO NOT install with this value):
+  # The previous version of this file shipped mongo_root_password: "SuperSecret"
+  # as a placeholder. That placeholder was getting propagated into real
+  # installs (vendor13-ib initially shipped with it) because nothing made
+  # the operator aware they had to change it. The sentinel <REPLACE_BEFORE_INSTALL>
+  # is invalid for MongoDB and forces the install to fail loudly if the
+  # operator forgets to override it.
+  #
+  # Required at install time:
+  #   --set mongodb.mongo_root_password='<your secret>'
+  #
+  # For a longer-lived install, prefer wiring this to an externally-managed
+  # Kubernetes Secret (the chart's mongodb subchart supports existingSecret
+  # via additional values overrides; not enabled by default in this example).
+  mongo_root_password: "<REPLACE_BEFORE_INSTALL>"
   image:
     repository: ironbank/opensource/mongodb/mongodb
     tag: 4.4.5

--- a/examples/enbuild/values-vendor13-ib.yaml
+++ b/examples/enbuild/values-vendor13-ib.yaml
@@ -8,6 +8,9 @@
 # Install as Helm release "enbuild-ib" so the chart's generated image pull
 # secret lines up with the sub-chart pullSecrets references:
 #
+#   # Operator must docker login first so creds aren't in shell history:
+#   docker login registry1.dso.mil -u <user>
+#
 #   helm install enbuild-ib ./charts/enbuild \
 #     --namespace enbuild --create-namespace \
 #     --values examples/enbuild/values-vendor13-ib.yaml \
@@ -15,7 +18,11 @@
 #     --set global.image.registry_credentials.username=<registry1 username> \
 #     --set global.image.registry_credentials.password=<registry1 password>
 #
-# Open questions captured inline with TODO markers — resolve before final install.
+# Phase-5 deployment scope intentionally minimal: no DNS hostname, no SSO,
+# no IRSA. Access via `kubectl port-forward` and ENBUILD local-admin login.
+# Follow-on phases add DNS, Istio VirtualService, SSO, and Pod Identity for
+# the mq-consumer (the cluster's OIDC provider is already registered in IAM
+# at arn:aws-us-gov:iam::219533807077:oidc-provider/oidc.eks.us-gov-west-1.amazonaws.com/id/48EA4C3B972522B4A77C3643EAFE1512).
 
 global:
   AppVersion: 1.0.30


### PR DESCRIPTION
## Summary

Hardens the ENBUILD Helm chart for P1 GovCloud (vendor13-ib) production readiness. Three connected concerns bundled in one branch because they all touch the same files and were validated together against the live cluster.

## What this PR does

### 1. Operator-managed secret support (the original scope)

Adds three backwards-compatible value paths so P1 environments can rotate the GitLab PAT and the CCM-32 audit-export-bundle ECDSA signing key out-of-band — without putting either in `values.yaml`.

| Value path | Purpose |
|---|---|
| `enbuildBk.gitlabPat.existingSecret` | Name of an operator-managed Secret carrying `GITLAB_TOKEN`. When set, the deployment adds an extra `envFrom` and the inline `GITLAB_TOKEN` is omitted to avoid duplicate envvars. |
| `enbuildBk.exportSigning.existingSecret` | Name of an operator-managed Secret carrying `SIEM_SIGNING_KEY` (PEM ECDSA P-256 private key for `/audit/export-bundle`). Strongly preferred over inline for production. |
| `enbuildBk.exportSigning.privateKeyPem` | Inline PEM. Dev/test only. |

All three default to empty — rendered output is byte-identical to the prior chart version when none are set.

This unblocks production-survivability on `vendor13-ib`, where both secrets are currently maintained as in-cluster JSON-patches that a `helm upgrade` would wipe.

### 2. Three production-regression fixes that bit vendor13-ib

| Bug | Fix | Files |
|---|---|---|
| **nginx server_name** dropped `localhost` from the chart's server block. The Iron Bank base image's default server block (also listening on 8080 with `server_name localhost`) won the Host: localhost match for any `kubectl port-forward` request. UI loaded but every API call returned the React 404 HTML. Took hours to root-cause; symptoms misread as "auth broken" / "config.js wrong" first. | `server_name localhost _;` so the chart block ties on hostname match and wins on `default_server`. | `templates/nginx-conf.yaml` |
| **mq-consumer liveness probe** ran `node src/queue/testConnection.js` directly. The Iron Bank `enbuild-mq` image ships multiple `node` binaries; only `/usr/bin/node` loads `libatomic.so.1` correctly. Plain `node` resolved to the wrong binary, the probe failed, and the kubelet killed the pod every minute. **45 restarts in ~4 hours on vendor13-ib (2026-04-20)** before the workaround was applied. | Default probe is now a shell wrapper with absolute `/usr/bin/node` + explicit `PATH`. Operators can override via `enbuildConsumer.livenessProbe`. | `templates/enbuild-mq.yaml` |
| **rabbitmq securePassword** — bitnami's default `securePassword: true` causes the chart to generate a random admin password and IGNORE `auth.password`. After a PVC wipe, freshly created admin user has a NEW random password while the backend still connects with the configured one. **~3h outage on vendor13-ib (2026-04-30)** until someone ran `rabbitmqctl change_password admin SuperSecret` manually. | Set `securePassword: false` so the chart honors `auth.password`. PVC wipe re-creates the admin user with the configured password and backend reconnects without intervention. | `values.yaml` |

All three are chart-template-only (no app-code change). All would have been caught by a 5-minute kind-install + curl loop, which leads to:

### 3. CI quality gates + helm test (so this regression class can't reach main again)

| File | Purpose |
|---|---|
| `.github/workflows/helm-pr-checks.yml` | New PR-time workflow. Two jobs: `lint-and-template` (helm lint + template + kubeconform on every example values file) and `kind-install-smoke` (kind cluster + helm install + curl the `/enbuild-bk/`, `/enbuild-user/`, `/headlamp/` proxy paths through the UI service to catch the nginx server_name regression class; also waits 3 probe periods and asserts mq pod has 0 restarts to catch probe-PATH regressions). |
| `templates/tests/test-connection.yaml` | New `helm test` Pod that exercises the same UI nginx proxy chain end-to-end after install. Run with `helm test <release> -n <namespace>`. Designed to fail loudly on the same regression class. |
| `TROUBLESHOOTING.md` (new) | Documents both fixed bugs (with `*Symptom* → *Cause* → *Fix*` format) plus install-time issues (image pull secrets, Mongo password sentinel, etc.), a chart-side-vs-cluster-side categorization, and pointers to the helm test for self-verification. |
| `README.md` | One-line link to TROUBLESHOOTING.md + a `helm test` recommendation post-install. |

### 4. New `examples/enbuild/values-vendor13-ib.yaml`

P1 GovCloud-specific overlay extending the existing `quick_install_ib_headlamp.yaml` baseline. Phase-5 minimal scope (no DNS, SSO, IRSA — added in follow-on phases). Comments explain TODOs for the operator (Route53 record, Istio VirtualService, IRSA Pod Identity for mq-consumer).

### 5. Two pre-existing chart bugs the new CI surfaced

When the new `helm-pr-checks.yml` workflow ran for the first time it caught two bugs that have been on `main` for a while. Both were 1-line fixes brought into scope here so this PR's own CI can pass:

| File:line | Bug | Fix |
|---|---|---|
| `templates/NOTES.txt:11` | Referenced `.Values.frontend_service.port` which doesn't exist in any values schema. Caused `helm lint` to fail on `loadbalancer.yaml` with a nil-pointer. | Replaced with literal `80` (matches the ClusterIP echo line above; the chart's UI Service exposes port 80 by default). |
| `templates/mongodb.yaml:85,92` | Mongo Service had two `type:` fields — line 85 `type: {{ .Values.mongodb.type }}` (renders empty when unset) and line 92 hardcoded `type: ClusterIP`. Caused `kubeconform` to fail on every example with `key "type" already set in map`. | Made the configurable one default to ClusterIP and removed the hardcoded duplicate: `type: {{ .Values.mongodb.type \| default "ClusterIP" }}`. |

## CodeRabbit review — addressed in commit `824011e`

Two `🟠 Major` items from CodeRabbit's review fixed:

| CodeRabbit finding | Fix |
|---|---|
| **Pin GitHub Actions to commit SHAs, not mutable version tags.** Using `@v4`/`@v1` allows upstream tag retargeting and weakens CI supply-chain integrity. | All `uses:` entries now pinned to full commit SHAs with comment annotation showing the tag they correspond to. `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1`, `azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1`, `helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1`. |
| **kubeconform binary checksum verification.** A re-released tarball with a new payload would currently slip through. | Download path split: `curl -fsSL -o /tmp/kubeconform.tar.gz` + `sha256sum -c -` against the upstream-published SHA256 (`95f14e87aa28...`) before extract. |
| **`test-connection.yaml` status validation too loose.** Lines 54-59 currently treated any non-404 (incl. 500 / 502 / 000) as PASS, weakening the test as a release gate. | Replaced `if [ "$code" = "404" ]` with explicit `case` statement: `200|401|403` PASS, `404` FAIL with regression-specific message, anything else FAIL with unexpected-status message. |

The four `🟡 Minor` items (markdownlint code-block language tags, README parameters table doc, fixed `sleep 5` → active readiness loop, kubeconform checksum) — three are docs polish (deferred); the fourth (active readiness loop) is genuine reliability improvement for CI flake but small enough to follow-up if CI starts flaking.

## Backwards compatibility

- **Secret-management value paths** all default to empty — no chart consumer is affected unless they opt in.
- **nginx server_name** change is additive (`_` → `localhost _`), strictly more permissive Host matching. Production access via Istio gateway uses non-localhost Host headers and is unaffected.
- **mq probe** change is overridable via `enbuildConsumer.livenessProbe` for operators with custom probe shapes; default is a strict-superset of prior behavior on every supported image.
- **rabbitmq securePassword: false** — change in behavior. Existing deployments with set `auth.password` now respect it after PVC wipe (was previously ignored). No-op for deployments using a randomly generated password they didn't track.
- **NOTES.txt port literal** — purely cosmetic (output of `helm install`); no rendered K8s resource changes.
- **Mongo Service type default** — was implicitly ClusterIP via the hardcoded line; now explicit via Values default. No behavior change unless a consumer was setting `mongodb.type` to something other than ClusterIP (which would have been broken before too because of the dup-type field).

## Verification

```
# helm lint passes on all 10 example values files (was 1 failing on main)
for f in examples/enbuild/*.yaml; do helm lint ./charts/enbuild --values "$f"; done

# helm template + kubeconform passes on all 10 examples (was failing every time on main)
for f in examples/enbuild/*.yaml; do
  helm template enbuild-test ./charts/enbuild --values "$f" \
    --set global.image.registry_credentials.username=fake \
    --set global.image.registry_credentials.password=fake \
    --set mongodb.mongo_root_password=fake \
    | kubeconform -strict -summary -ignore-missing-schemas
done

# helm template against vendor13-ib overlay renders cleanly:
helm template enbuild-ib charts/enbuild -f examples/enbuild/values-vendor13-ib.yaml \
  --set global.image.registry_credentials.username=fake \
  --set global.image.registry_credentials.password=fake \
  --set mongodb.mongo_root_password=fake

# helm upgrade --dry-run against the live vendor13-ib cluster — no diff in
# rendered backend Deployment when overlay values are empty (default state).
```
