### PR TITLE
fix(values-vendor13-ib): include /opt/bitnami/git/bin in mq-consumer PATH wrapper

### DIFF
--- a/examples/enbuild/values-vendor13-ib.yaml
+++ b/examples/enbuild/values-vendor13-ib.yaml
@@ -111,11 +111,18 @@ enbuildConsumer:
     repository: ironbank/vivsoft/enbuild/enbuild-mq
     tag: 1.0.30-5101532
   # The Iron Bank MQ image works when npm resolves node from /usr/bin first.
+  # /opt/bitnami/git/bin must stay on PATH so createStack.js's shelled-out
+  # `git init && git push` (used to seed each new GitLab deployment project)
+  # resolves the git binary. Without it, every GitLab-flavored stack create
+  # fails with `/bin/sh: line 2: git: command not found` and
+  # `Gitlab couln't initialize project after 100 tries`. Surfaced 2026-05-11
+  # during CCM-05c RKE2 verification; see
+  # p1-cluster-mgmt/evidence/ccm-05c/06-enbuild-bugs-discovered-2026-05-11.md.
   command:
     - /bin/sh
     - -lc
   args:
-    - export PATH=/usr/bin:/usr/sbin:/bin:/sbin:/usr/local/bin && exec /usr/bin/npm run run:mq:all
+    - export PATH=/opt/bitnami/git/bin:/usr/bin:/usr/sbin:/bin:/sbin:/usr/local/bin && exec /usr/bin/npm run run:mq:all
   # NOTE: no livenessProbe override needed — chart's default is now IB-safe
   # (uses shell wrapper + /usr/bin/node). See enbuild-mq.yaml template comment
   # for the full WHY. Set livenessProbe here only if you want a different


### PR DESCRIPTION
## Summary

Prepends `/opt/bitnami/git/bin` (the filesystem path where `git` is bundled inside the IronBank `enbuild-mq` image — see "On the path" note below) to the explicit `PATH` exported by the mq-consumer container's start wrapper for the vendor13-ib values override. Without it, the mq-consumer's shelled-out `git init && git push` calls in `createStack.js` fail with `/bin/sh: line 2: git: command not found`, which cascades to `Gitlab couln't initialize project after 100 tries` and blocks every GitLab-flavored stack create on vendor13-ib.

## On the path (registry / hardening clarification)

We are still pulling **only from the IronBank registry**:

```
registry1.dso.mil/ironbank/vivsoft/enbuild/enbuild-mq:1.0.30-5101532
```

The `/opt/bitnami/git/bin/git` string in this PR is a **filesystem path *inside* that IronBank-hardened image** — it's just where the git binary happens to live in the image's layout (the upstream layer that bundles `git` placed it there). It is **not** a separate registry, image, or dependency. Nothing in this PR pulls from a Bitnami registry or changes which registry the chart points at.

## Root cause

The IronBank `enbuild-mq` image ships `git` at `/opt/bitnami/git/bin/git` — **not** the standard `/usr/bin/git`. The chart wrapper was previously:

```yaml
args:
  - export PATH=/usr/bin:/usr/sbin:/bin:/sbin:/usr/local/bin && exec /usr/bin/npm run run:mq:all
```

This `export PATH=...` overrides anything set via the Deployment's `env:` and strips the directory that actually contains `git`. Node inherits the wrapper's PATH; the shelled-out git invocations in `createStack.js` fail because `git` is not on PATH.

## Fix

Add the bundled-git directory to the wrapper's `PATH`:

```yaml
args:
  - export PATH=/opt/bitnami/git/bin:/usr/bin:/usr/sbin:/bin:/sbin:/usr/local/bin && exec /usr/bin/npm run run:mq:all
```

Single-line change in `examples/enbuild/values-vendor13-ib.yaml`. Comment block explains the why so it doesn't get stripped on future cleanups.

## Surface area / blast radius

- File touched: `examples/enbuild/values-vendor13-ib.yaml` only
- Affects: vendor13-ib helm release only (other environments have their own values files)
- Registry pulled: still `registry1.dso.mil/ironbank/vivsoft/enbuild/enbuild-mq` (unchanged)
- Backward compatible: equivalent to the in-cluster `kubectl patch` already applied; this PR codifies it in the chart

## How this was discovered

Surfaced 2026-05-11 during CCM-05c (RKE2 on AWS GovCloud) verification. After diagnosis, an in-cluster `kubectl patch deployment` was applied to unblock the immediate work. This PR codifies that patch in the Helm chart so it survives reconciliation / future `helm upgrade`. Evidence under `p1-cluster-mgmt/evidence/ccm-05c/06-enbuild-bugs-discovered-2026-05-11.md`.

## Test plan

After merge, on vendor13-ib:

- [ ] `helm upgrade enbuild-ib ./charts/enbuild --values examples/enbuild/values-vendor13-ib.yaml --reuse-values` — verify the mq-consumer pod rolls
- [ ] `kubectl -n enbuild exec <new-mq-pod> -- /bin/sh -c 'cat /proc/1/environ | tr "\0" "\n" | grep ^PATH='` — should include `/opt/bitnami/git/bin`
- [ ] POST a fresh stack via ENBUILD UI/API — should reach pipeline trigger without `git: command not found` errors. (CCM-05c verification today already proved this works with the kubectl patch; this PR just makes it durable.)

## Related work

- Paired with vivsoft-platform-ui MR https://gitlab.com/enbuild-staging/vivsoft-platform-ui/-/merge_requests/1149 (mq-consumer per-stack `ref` source fix; separate ENBUILD bug also surfaced during CCM-05c verification)
- Source commit cherry-picked from `feat/p1ccm-hub-grpc-service` `00261da`
