### PR TITLE
feat(chart): add optional enbuildConsumer.image.registry override

### DIFF
--- a/charts/enbuild/templates/enbuild-mq.yaml
+++ b/charts/enbuild/templates/enbuild-mq.yaml
@@ -29,7 +29,14 @@ spec:
             name: {{ .Release.Name }}-mongo-secrets
         - secretRef:
             name: {{ .Release.Name }}-backend-secret
-        image: {{ .Values.global.image.registry }}/{{ .Values.enbuildConsumer.image.repository }}:{{ default .Chart.AppVersion (default .Values.global.AppVersion .Values.enbuildConsumer.image.tag) }}
+        # Image registry: per-service `enbuildConsumer.image.registry` override
+        # wins over the chart-wide `global.image.registry`. Unset by default →
+        # falls back to global, preserving every existing deploy's behavior.
+        # Use case: vendor13-ib temporarily points at the GitLab staging
+        # registry to consume a fix while waiting for the Iron Bank rebuild to
+        # ship the same change. See examples/enbuild/values-vendor13-ib.yaml
+        # for the override shape + intended temporary lifecycle.
+        image: {{ default .Values.global.image.registry .Values.enbuildConsumer.image.registry }}/{{ .Values.enbuildConsumer.image.repository }}:{{ default .Chart.AppVersion (default .Values.global.AppVersion .Values.enbuildConsumer.image.tag) }}
         imagePullPolicy: {{ .Values.global.image.pullPolicy }}
         # WHY this default probe shells out and prefers /usr/bin/node:
         # The Iron Bank enbuild-mq image

--- a/charts/enbuild/values.yaml
+++ b/charts/enbuild/values.yaml
@@ -180,6 +180,7 @@ enbuildUser:
   service_type: ClusterIP
 
 ## @section ENBUILD Consumer Services parameters
+## @param enbuildConsumer.image.registry [nullable,string] Per-service registry override. Unset → falls back to `global.image.registry`. Use to consume an mq-consumer image from a non-default registry (e.g. GitLab staging while waiting for an Iron Bank rebuild). Leave unset for normal deployments.
 ## @param enbuildConsumer.image.repository  Container repository for enbuildConsumer
 ## @param enbuildConsumer.image.tag [nullable] Container image tag. Skip to use the HelmChart appVersion as Image Tag
 ## @param enbuildConsumer.replicas Container enbuildConsumer Replicas


### PR DESCRIPTION
## Summary

Adds an optional `enbuildConsumer.image.registry` Helm value. When set, it overrides `global.image.registry` **for the mq-consumer container only**. When unset (the default), behavior is identical to today.

This is the third piece of the CCM-05c (RKE2 on AWS GovCloud) unblock chain. The first two PRs (#42 here, MR !1149 on vivsoft-platform-ui) landed source/chart fixes. This PR adds the deployment-level knob that lets vendor13-ib actually consume the GitLab-staging mq-consumer image while we wait for the Iron Bank rebuild to ship the same code.

## Why we need this

The Iron Bank `enbuild-mq` image only rebuilds when Iron Bank's pipeline picks up a new release tag from the upstream source — that's typically days behind the source merge. The two upstream fixes are merged to `dev` but won't reach `registry1.dso.mil/ironbank/vivsoft/enbuild/enbuild-mq` until Iron Bank cycles. Meanwhile, vendor13-ib has the same fixes available immediately at `registry.gitlab.com/enbuild-staging/vivsoft-platform-ui/enbuild-mq-consumer:<sha>`.

Without this knob, vendor13-ib has no clean way to pull from a non-default registry for just one container. The chart's template currently hardcodes `global.image.registry` for every component.

## What changes

Two files touched:

**`charts/enbuild/templates/enbuild-mq.yaml`** — one templated line goes from:
```yaml
image: {{ .Values.global.image.registry }}/{{ .Values.enbuildConsumer.image.repository }}:{{ ... }}
```
to:
```yaml
image: {{ default .Values.global.image.registry .Values.enbuildConsumer.image.registry }}/{{ .Values.enbuildConsumer.image.repository }}:{{ ... }}
```

Comment block above the line explains the why so future cleanups don't strip the `default` wrapping. (The `default A B` Helm function returns B if B is truthy, else A — so this reads as "use the per-service registry override if set, else fall back to global.")

**`charts/enbuild/values.yaml`** — adds one `@param` doc line under the `## @section ENBUILD Consumer Services parameters` block for the new field. The default-value block itself is unchanged (the override is unset by default).

## Isolation / blast radius

| Consumer | Impact |
|---|---|
| Existing values files that don't set the new field | **None.** `default` falls back to `global.image.registry` — identical to current behavior. |
| Other engineers' local dev / kind clusters | **None** (unless they explicitly opt in) |
| CI smoke tests | **None** (unless they explicitly opt in) |
| Other chart components (frontend, backend, user-service, ai, agent, mongo, rabbitmq) | **None** — template change is scoped to `enbuild-mq.yaml` only |
| Vendor13-ib (where the override will be set in a follow-up commit) | Pulls mq from `registry.gitlab.com/.../enbuild-mq-consumer:<sha>` instead of Iron Bank |
| When Iron Bank rebuilds | Vendor13-ib values can clear the override → back to Iron Bank with one line removed |

## What's intentionally NOT in this PR

- The actual vendor13-ib values change (setting `enbuildConsumer.image.registry: registry.gitlab.com` and bumping the tag) — deferred to a follow-up because the CI image tag isn't built yet at this moment. Once `dev` CI completes, a small values-only commit will land that override.
- Pull-secret plumbing for `registry.gitlab.com` — operator-provided (out-of-band Secret), same pattern as the existing `registry1.dso.mil` pull secret. Will be set up by the operator at apply time.

## Test plan

Existing deploys (any environment, any operator):
- [ ] Render the chart with default values: `helm template ./charts/enbuild` — verify the mq-consumer image line still resolves to `<global.image.registry>/<enbuildConsumer.image.repository>:<tag>`. Should be identical to current output.
- [ ] Render with override: `helm template ./charts/enbuild --set enbuildConsumer.image.registry=registry.gitlab.com` — image line now resolves to `registry.gitlab.com/<repository>:<tag>`.

Vendor13-ib (after this PR + the follow-up values-only commit lands):
- [ ] `helm upgrade enbuild-ib ./charts/enbuild --values examples/enbuild/values-vendor13-ib.yaml --reuse-values`
- [ ] `kubectl -n enbuild get pod -l app=mq -o jsonpath='{.items[0].spec.containers[?(@.name=="enbuild-mq")].image}'` — should show the new gitlab.com image path
- [ ] POST a fresh stack via ENBUILD; verify (a) `git: command not found` no longer appears (PR #42 + chart wrapper), and (b) the per-component tfvars override renders correctly with no `REPLACE-ME` placeholders (MR !1149's fix bakes into the new image)

## Related work

- Companion PR: https://github.com/vivsoftorg/enbuild/pull/42 (PATH wrapper fix on vendor13-ib values)
- Companion MR: https://gitlab.com/enbuild-staging/vivsoft-platform-ui/-/merge_requests/1149 (mq-consumer per-stack ref source fix)
- Discovery context: `p1-cluster-mgmt/evidence/ccm-05c/06-enbuild-bugs-discovered-2026-05-11.md`
