### PR TITLE
feat(chart): support GitLab Container Registry credentials in pull secret

### DIFF
--- a/charts/enbuild/templates/_helpers.tpl
+++ b/charts/enbuild/templates/_helpers.tpl
@@ -64,8 +64,36 @@ Create the name of the service account to use
 {{- end }}
 {{- end }}
 
+{{- /*
+  Build a Docker config.json containing one OR more registry auth entries,
+  ready for inclusion in a kubernetes.io/dockerconfigjson Secret.
+
+  Always includes the primary registry (.Values.global.image.registry +
+  .registry_credentials). Optionally adds a second entry for the GitLab
+  Container Registry if .Values.global.gitlabRegistryCredentials.username
+  is non-empty.
+
+  Why two registries: vendor13-ib (and similar prototype-iteration setups)
+  occasionally need to pull container images from the GitLab staging
+  registry (registry.gitlab.com/enbuild-staging/vivsoft-platform-ui/*)
+  ahead of the Iron Bank rebuild cycle. Merging both registries' auth
+  into ONE Secret means every existing Deployment that references
+  `{{ .Release.Name }}-image-pull-secret` automatically gains access to
+  both — no per-service plumbing change required.
+
+  Both blocks read placeholder values from values.yaml (e.g.
+  REGISTRY1_USER_NAME); operators supply real values at install time via
+  --set or a separate untracked secrets values file. Real credentials are
+  never committed.
+*/}}
 {{- define "imagePullSecret" }}
-{{- with .Values.global.image }}
-{{- printf "{\"auths\":{\"%s\":{\"username\":\"%s\",\"password\":\"%s\",\"auth\":\"%s\"}}}" .registry .registry_credentials.username .registry_credentials.password (printf "%s:%s" .registry_credentials.username .registry_credentials.password | b64enc) | b64enc }}
+{{- $primary := dict "registry" .Values.global.image.registry "creds" .Values.global.image.registry_credentials }}
+{{- $secondary := .Values.global.gitlabRegistryCredentials | default dict }}
+{{- $auths := dict }}
+{{- $_ := set $auths $primary.registry (dict "username" $primary.creds.username "password" $primary.creds.password "auth" (printf "%s:%s" $primary.creds.username $primary.creds.password | b64enc)) }}
+{{- if and $secondary.username $secondary.password }}
+{{- $gitlabHost := default "registry.gitlab.com" $secondary.registry }}
+{{- $_ := set $auths $gitlabHost (dict "username" $secondary.username "password" $secondary.password "auth" (printf "%s:%s" $secondary.username $secondary.password | b64enc)) }}
 {{- end }}
+{{- dict "auths" $auths | toJson | b64enc }}
 {{- end }}

--- a/charts/enbuild/values.yaml
+++ b/charts/enbuild/values.yaml
@@ -34,9 +34,18 @@ global:
     registry: registry.gitlab.com
     pullPolicy: Always
     registry_credentials: {}
-  storageClass: ""
     # username: registry_user_name
     # password: registry_password
+
+  ## @param global.gitlabRegistryCredentials.username [nullable,string] Optional GitLab Container Registry username (or "oauth2" when password is a PAT). Leave unset on normal deploys; supply via --set at install time when an environment needs to pull images from registry.gitlab.com in addition to the primary `global.image.registry`. Pairs with `password` below.
+    ## @param global.gitlabRegistryCredentials.password [nullable,string] GitLab Container Registry password / PAT (with read_registry scope). NEVER commit a real value; provide via --set or an untracked secrets values file at install time.
+    ## @param global.gitlabRegistryCredentials.registry [default: "registry.gitlab.com"] GitLab Container Registry host. Overridable for self-hosted GitLab instances (rare).
+  gitlabRegistryCredentials: {}
+    # registry: registry.gitlab.com
+    # username: GITLAB_USER_NAME
+    # password: GITLAB_PASSWORD_OR_PAT
+
+  storageClass: ""
 
 ## @section ENBUILD Lightning Features to be enabled
 ## @param lightning_features.develop_lightning.application [default: false] Enable Bolt deployment


### PR DESCRIPTION
## Summary

Extends the chart's `imagePullSecret` helper so the generated `kubernetes.io/dockerconfigjson` Secret can carry auth entries for **both** the primary registry (existing `global.image.registry` + `registry_credentials`) **and** an optional GitLab Container Registry (new `global.gitlabRegistryCredentials`). Surfaced by — and unblocks — the current `enbuild-backend` `ImagePullBackOff` on vendor13-ib.

## Why this is needed

On vendor13-ib the `enbuild-backend` Deployment was migrated to pull from `registry.gitlab.com/enbuild-staging/vivsoft-platform-ui/enbuild-backend@sha256:…` (faster iteration than waiting for the Iron Bank rebuild cycle on every source change). The image URL was updated; the pull-secret plumbing wasn't. Result: the pod has been in `ImagePullBackOff` for ~20h, kubelet logs show:

```
Warning  FailedToRetrieveImagePullSecret  ... Unable to retrieve some image pull secrets (private-registry)
Normal   BackOff                          ... Back-off pulling image "registry.gitlab.com/.../enbuild-backend@sha256:…"
```

The chart's existing pull secret (`{release}-image-pull-secret`) only carries `registry1.dso.mil` (Iron Bank) credentials. Kubernetes can't authenticate to gitlab.com → pull fails.

Pairs with [PR #43](https://github.com/vivsoftorg/enbuild/pull/43) (per-service registry override for mq-consumer). PR #43 enables ​a Deployment to *target* a different registry; this PR makes Kubernetes actually able to *authenticate* to that registry.

## What changes

Two files touched.

**`charts/enbuild/templates/_helpers.tpl`** — the `imagePullSecret` define is rewritten to merge auth entries into a single `auths{}` map. Pseudocode:

```yaml
auths:
  <global.image.registry>: { username, password, auth }       # always present (existing behavior)
  <global.gitlabRegistryCredentials.registry|default registry.gitlab.com>: { ... }   # added IFF gitlab creds are set
```

Same output shape as before when the new block is unset (single-entry auths).

**`charts/enbuild/values.yaml`** — adds the documented `global.gitlabRegistryCredentials` block as an empty default (`{}`). Three nested fields documented inline:

| Field | Purpose |
|---|---|
| `username` | GitLab username, or the string `oauth2` when `password` is a PAT |
| `password` | GitLab password / Personal Access Token with `read_registry` scope |
| `registry` (optional) | Override host. Defaults to `registry.gitlab.com`; only set for self-hosted GitLab |

**Real credentials are never committed.** `values.yaml` ships an empty `{}`; operators supply real values at `helm install` / `helm upgrade` time via `--set` flags or an untracked secrets values file — same pattern the chart already uses for `global.image.registry_credentials.username/password` (which are also placeholders in values files).

Example install command for vendor13-ib once this PR merges:

```bash
helm upgrade enbuild-ib ./charts/enbuild \
  --values examples/enbuild/values-vendor13-ib.yaml \
  --reuse-values \
  --set global.gitlabRegistryCredentials.username=<gitlab-user> \
  --set global.gitlabRegistryCredentials.password=<gitlab-pat-with-read_registry>
```

## Verified output (helm template, locally)

With Iron Bank as primary + GitLab secondary supplied:

```bash
helm template test charts/enbuild \
  --set global.image.registry=registry1.dso.mil \
  --set global.image.registry_credentials.username=ironbank-u \
  --set global.image.registry_credentials.password=ironbank-p \
  --set global.gitlabRegistryCredentials.username=gitlab-u \
  --set global.gitlabRegistryCredentials.password=gitlab-p
```

Renders Secret with both entries:

```json
{
  "auths": {
    "registry1.dso.mil":   { "username": "ironbank-u", "password": "ironbank-p", "auth": "…" },
    "registry.gitlab.com": { "username": "gitlab-u",   "password": "gitlab-p",   "auth": "…" }
  }
}
```

With `global.gitlabRegistryCredentials` unset (default), the output is the same single-entry secret as today's chart — zero behavior change for environments that don't need it.

## Isolation / blast radius

| Consumer | Impact |
|---|---|
| Existing deploys not setting `global.gitlabRegistryCredentials` | **None.** Helper produces the same single-auth Secret as today. |
| CI smokes, other engineers' kind clusters | **None** (don't opt in) |
| Per-service Deployment templates (frontend, backend, mq, user, ai, agent, …) | **None** — they all already reference `{release}-image-pull-secret` by name. They automatically gain second-registry auth when the values block is set. |
| vendor13-ib (when this PR merges + operator passes the new `--set` flags) | Backend pod picks up gitlab.com auth on next pull attempt; mq-consumer + any future pods pulling from gitlab.com work too. |

## Test plan

After merge, on vendor13-ib:

- [ ] `helm upgrade enbuild-ib ./charts/enbuild --values examples/enbuild/values-vendor13-ib.yaml --reuse-values --set global.gitlabRegistryCredentials.username=<u> --set global.gitlabRegistryCredentials.password=<pat>` — verify the `{release}-image-pull-secret` Secret now contains both `registry1.dso.mil` and `registry.gitlab.com` auth entries: `kubectl -n enbuild get secret enbuild-ib-image-pull-secret -o jsonpath='{.data.\.dockerconfigjson}' | base64 -d | jq '.auths | keys'`
- [ ] `enbuild-backend` pod transitions from `ImagePullBackOff` → `Running` within one or two backoff cycles (kubelet retries pull on Secret update)
- [ ] `curl http://localhost:3001/enbuild-bk/api/v1/manifests` (via the UI port-forward) returns HTTP 200 — confirms `/enbuild-bk/*` is reachable through the now-running backend
- [ ] Set the mq-consumer registry override (after [PR #43](https://github.com/vivsoftorg/enbuild/pull/43) merges) and confirm mq-consumer pod also pulls cleanly from gitlab.com

## Related work

- Companion PR (per-service registry override): https://github.com/vivsoftorg/enbuild/pull/43
- vivsoft-platform-ui upstream fix this image consumes: https://gitlab.com/enbuild-staging/vivsoft-platform-ui/-/merge_requests/1149 (merged)
- Discovery context: `p1-cluster-mgmt/evidence/ccm-05c/06-enbuild-bugs-discovered-2026-05-11.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for secondary container registry credentials, enabling image pulls from GitLab registries alongside the primary registry.
  * New configuration options for optional GitLab registry authentication with customizable registry host.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vivsoftorg/enbuild/pull/44)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->