### PR TITLE
feat(chart): per-service image.registry override on bk/ui/user/ai/ctf (extends #43 pattern)

### DIFF
--- a/charts/enbuild/templates/enbuild-ai.yaml
+++ b/charts/enbuild/templates/enbuild-ai.yaml
@@ -49,7 +49,10 @@ spec:
         - secretRef:
             name: {{ .Release.Name }}-backend-secret
         imagePullPolicy: {{ .Values.global.image.pullPolicy }}
-        image: {{ .Values.global.image.registry }}/{{ .Values.enbuildAI.image.repository }}:{{ default .Chart.AppVersion (default .Values.global.AppVersion .Values.enbuildAI.image.tag) }}
+        # Image registry: per-service `enbuildAI.image.registry` override
+        # wins over the chart-wide `global.image.registry`. Unset by default →
+        # falls back to global. See enbuild-mq.yaml for the use-case writeup.
+        image: {{ default .Values.global.image.registry .Values.enbuildAI.image.registry }}/{{ .Values.enbuildAI.image.repository }}:{{ default .Chart.AppVersion (default .Values.global.AppVersion .Values.enbuildAI.image.tag) }}
         name: enbuild-ai
         ports:
         - containerPort: 8000

--- a/charts/enbuild/templates/enbuild-bk.yaml
+++ b/charts/enbuild/templates/enbuild-bk.yaml
@@ -50,7 +50,14 @@ spec:
         - secretRef:
             name: {{ . }}
         {{- end }}
-        image: {{ .Values.global.image.registry }}/{{ .Values.enbuildBk.image.repository }}:{{ default .Chart.AppVersion (default .Values.global.AppVersion .Values.enbuildBk.image.tag) }}
+        # Image registry: per-service `enbuildBk.image.registry` override
+        # wins over the chart-wide `global.image.registry`. Unset by default →
+        # falls back to global, preserving every existing deploy's behavior.
+        # Use case: vendor13-ib temporarily points at the GitLab staging
+        # registry to consume a fix while waiting for the Iron Bank rebuild to
+        # ship the same change. See examples/enbuild/values-vendor13-ib.yaml
+        # for the override shape + intended temporary lifecycle.
+        image: {{ default .Values.global.image.registry .Values.enbuildBk.image.registry }}/{{ .Values.enbuildBk.image.repository }}:{{ default .Chart.AppVersion (default .Values.global.AppVersion .Values.enbuildBk.image.tag) }}
         imagePullPolicy: {{ .Values.global.image.pullPolicy }}
         livenessProbe:
           failureThreshold: 3

--- a/charts/enbuild/templates/enbuild-ctf.yaml
+++ b/charts/enbuild/templates/enbuild-ctf.yaml
@@ -43,7 +43,10 @@ spec:
             name: {{ .Release.Name }}-mongo-secrets
         - secretRef:
             name: {{ .Release.Name }}-backend-secret
-        image: {{ .Values.global.image.registry }}/{{ .Values.enbuildCTF.image.repository }}:{{ default .Chart.AppVersion (default .Values.global.AppVersion .Values.enbuildCTF.image.tag) }}
+        # Image registry: per-service `enbuildCTF.image.registry` override
+        # wins over the chart-wide `global.image.registry`. Unset by default →
+        # falls back to global. See enbuild-mq.yaml for the use-case writeup.
+        image: {{ default .Values.global.image.registry .Values.enbuildCTF.image.registry }}/{{ .Values.enbuildCTF.image.repository }}:{{ default .Chart.AppVersion (default .Values.global.AppVersion .Values.enbuildCTF.image.tag) }}
         imagePullPolicy: {{ .Values.global.image.pullPolicy }}
         livenessProbe:
           failureThreshold: 3

--- a/charts/enbuild/templates/enbuild-ui.yaml
+++ b/charts/enbuild/templates/enbuild-ui.yaml
@@ -35,7 +35,10 @@ spec:
           value: {{ .Values.enbuildUi.grafana_url }}
         - name: COST_UTILIZATION_KUBECOST_IFRAME_URL
           value: {{ .Values.enbuildUi.kubecost_url }}
-        image: {{ .Values.global.image.registry }}/{{ .Values.enbuildUi.image.repository }}:{{ default .Chart.AppVersion (default .Values.global.AppVersion .Values.enbuildUi.image.tag) }}
+        # Image registry: per-service `enbuildUi.image.registry` override
+        # wins over the chart-wide `global.image.registry`. Unset by default →
+        # falls back to global. See enbuild-mq.yaml for the use-case writeup.
+        image: {{ default .Values.global.image.registry .Values.enbuildUi.image.registry }}/{{ .Values.enbuildUi.image.repository }}:{{ default .Chart.AppVersion (default .Values.global.AppVersion .Values.enbuildUi.image.tag) }}
         imagePullPolicy: {{ .Values.global.image.pullPolicy }}
         name: enbuild-ui
         resources: {}

--- a/charts/enbuild/templates/enbuild-user.yaml
+++ b/charts/enbuild/templates/enbuild-user.yaml
@@ -28,7 +28,10 @@ spec:
             name: {{ .Release.Name }}-mongo-secrets
         - secretRef:
             name: {{ .Release.Name }}-backend-secret
-        image: {{ .Values.global.image.registry }}/{{ .Values.enbuildUser.image.repository }}:{{ default .Chart.AppVersion (default .Values.global.AppVersion .Values.enbuildUser.image.tag) }}
+        # Image registry: per-service `enbuildUser.image.registry` override
+        # wins over the chart-wide `global.image.registry`. Unset by default →
+        # falls back to global. See enbuild-mq.yaml for the use-case writeup.
+        image: {{ default .Values.global.image.registry .Values.enbuildUser.image.registry }}/{{ .Values.enbuildUser.image.repository }}:{{ default .Chart.AppVersion (default .Values.global.AppVersion .Values.enbuildUser.image.tag) }}
         imagePullPolicy: {{ .Values.global.image.pullPolicy }}
         livenessProbe:
           failureThreshold: 3


### PR DESCRIPTION
## Summary
Extends the per-service `image.registry` override pattern that PR #43 added for `enbuildConsumer` to the remaining five Enbuild services: `enbuildBk`, `enbuildUi`, `enbuildUser`, `enbuildAi`, `enbuildCtf`.

Each service now accepts an optional `image.registry` field. When set, the deployment template uses that value; when unset, it falls back to `global.image.registry` — identical to today's behavior.

Companion to PR #44: the `global.gitlabRegistryCredentials` mechanism from #44 plus per-service `image.registry` from #43 + this PR lets a deploy mix images from Iron Bank and `registry.gitlab.com` in the same release without per-service plumbing.

## Why
vendor13-ib is currently in a state where the backend deployment was overridden to a `registry.gitlab.com` image via `kubectl set image` (because Iron Bank hadn't rebuilt the source-side fixes yet). That digest was later GC'd from the registry → 17h \`ImagePullBackOff\`. The proper fix is to land the override in Helm values so it survives reconciles. PR #43 enabled that for `enbuildConsumer` only; this PR extends to the other services so the same iteration pattern works end-to-end.

## Backwards compatibility
Strictly additive. Default for every new `<service>.image.registry` field is unset → falls back to `global.image.registry` → identical render output.

## Test plan
- [x] `helm lint charts/enbuild` — clean
- [x] `helm template charts/enbuild` — renders identical to main when no overrides set
- [ ] `helm upgrade` against vendor13-ib with `enbuildBk.image.registry=registry.gitlab.com` + SHA tag — verify pod pulls from gitlab.com + comes Ready
- [ ] Confirm `global.gitlabRegistryCredentials` populated → pull secret authenticates against both Iron Bank and gitlab.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration to support per-service image registry overrides. Services can now specify custom container image registries independently of the global default, enabling more flexible deployment management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vivsoftorg/enbuild/pull/45)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->