### PR TITLE
Round-1 G1: roll backend on Keycloak config change (checksum annotation)

### DIFF
--- a/charts/enbuild/Chart.yaml
+++ b/charts/enbuild/Chart.yaml
@@ -7,7 +7,7 @@ home: https://www.vivsoft.io/
 sources: [https://github.com/vivsoftorg/enbuild]
 icon: https://enbuild-docs.vivplatform.io/images/emma/enbuild-logo.png
 kubeVersion: '>=1.25.0-0'
-version: 0.1.0-p1ccm-trunk.17
+version: 0.1.0-p1ccm-trunk.20
 appVersion: 1.0.30
 maintainers:
   - name: Juned Memon

--- a/charts/enbuild/templates/enbuild-bk.yaml
+++ b/charts/enbuild/templates/enbuild-bk.yaml
@@ -15,6 +15,25 @@ spec:
     {{- include "enbuild-helm-chart.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      annotations:
+        {{- /*
+          FIX-E (G1, first-deploy findings): roll the backend automatically when
+          its Keycloak issuer/URL config changes. KEYCLOAK_ISSUER / KEYCLOAK_URL /
+          KEYCLOAK_BACKEND_URL ride {release}-backend-secret via envFrom and are
+          read ONCE at process boot — so a helm upgrade that only re-points the
+          issuer/URL updates the Secret but leaves the running pod verifying tokens
+          against the OLD issuer (strict endpoints 401, catalog stuck "Loading
+          templates…"). Checksumming just the KC issuer/URL values (mirrors the
+          effective-issuer derivation in backend-secret.yaml) rolls the pod on
+          exactly those changes, without coupling it to unrelated Secret edits.
+        */}}
+        {{- $kc := default (dict) .Values.enbuildBk.keycloak }}
+        {{- $kcRealm := default "enbuild" $kc.realm }}
+        {{- $kcIssuer := $kc.issuer }}
+        {{- if and (not $kcIssuer) $kc.url }}
+        {{- $kcIssuer = printf "%s/realms/%s" (trimSuffix "/" $kc.url) $kcRealm }}
+        {{- end }}
+        checksum/keycloak-config: {{ dict "issuer" $kcIssuer "url" $kc.url "backendUrl" $kc.backendUrl "realm" $kcRealm | toYaml | sha256sum }}
       labels:
         app: bk
         app.kubernetes.io/component: backend


### PR DESCRIPTION
FIX-E/G1 (SOO 3.1 first-deploy). Adds a checksum/keycloak-config pod annotation on the enbuild backend so any change to the KC issuer/URL config auto-rolls the backend (else the catalog gets stuck 'Loading templates' with strict endpoints returning 401). Chart bumped to 0.1.0-p1ccm-trunk.20. helm lint clean. Ref: p1-cluster-mgmt/runbooks/round1-3.1-fixes-spec.md (FIX-E).